### PR TITLE
Render player facing direction asset

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ DevEx:
 Backlog:
 
 - client
-  - [ ] create an entry point function for the client code which creates a canvas, connects to a server, and starts the game loop
+  - [x] create an entry point function for the client code which creates a canvas, connects to a server, and starts the game loop
   - [x] a user shall be able to move their player around with w,s,a,d
   - [x] a user shall be able to move in a diagonal direction
   - [x] a user shall be able to attack using space

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -8,9 +8,18 @@ export default function HomePage() {
   const clientRef = useRef<GameClient | null>(null);
 
   useEffect(() => {
-    if (canvasRef.current) {
+    async function initClient(): Promise<void> {
+      if (!canvasRef.current) {
+        return;
+      }
+
       clientRef.current = new GameClient(process.env.NEXT_PUBLIC_WEBSOCKET_URL!, canvasRef.current);
+
+      await clientRef.current.loadAssets();
+      clientRef.current.start();
     }
+
+    void initClient();
 
     return () => {
       clientRef.current?.unmount();

--- a/packages/game-client/src/entities/bullet.ts
+++ b/packages/game-client/src/entities/bullet.ts
@@ -1,16 +1,19 @@
 import { Entities, EntityType, Positionable, Vector2 } from "@survive-the-night/game-server";
+import { AssetManager } from "@/managers/asset";
 import { GameState } from "../state";
 import { IClientEntity, Renderable } from "./util";
 import { HITBOX_RADIUS } from "@survive-the-night/game-server/src/shared/entities/bullet";
 
 export class BulletClient implements IClientEntity, Renderable, Positionable {
+  private assetManager: AssetManager;
   private position: Vector2 = { x: 0, y: 0 };
   private type: EntityType;
   private id: string;
 
-  constructor(id: string) {
+  constructor(id: string, assetManager: AssetManager) {
     this.id = id;
     this.type = Entities.BULLET;
+    this.assetManager = assetManager;
   }
 
   getId(): string {

--- a/packages/game-client/src/entities/player.ts
+++ b/packages/game-client/src/entities/player.ts
@@ -5,12 +5,18 @@ import {
   roundVector2,
   Vector2,
   normalizeVector,
+  determineDirection,
+  isDirectionDown,
+  isDirectionLeft,
+  isDirectionRight,
+  isDirectionUp,
 } from "@survive-the-night/game-server";
+import { AssetManager } from "@/managers/asset";
 import { IClientEntity, Renderable } from "./util";
 import { GameState } from "@/state";
 
 export class PlayerClient implements IClientEntity, Renderable, Positionable {
-  private image = new Image();
+  private assetManager: AssetManager;
   private lastRenderPosition = { x: 0, y: 0 };
   private readonly LERP_FACTOR = 0.1;
   private position: Vector2 = { x: 0, y: 0 };
@@ -19,10 +25,32 @@ export class PlayerClient implements IClientEntity, Renderable, Positionable {
   private type: EntityType;
   private readonly ARROW_LENGTH = 20;
 
-  constructor(id: string) {
+  constructor(id: string, assetManager: AssetManager) {
     this.id = id;
     this.type = Entities.PLAYER;
-    this.image.src = "/player.png";
+    this.assetManager = assetManager;
+  }
+
+  getImage(): HTMLImageElement {
+    const direction = determineDirection(this.velocity);
+
+    if (direction && isDirectionLeft(direction)) {
+      return this.assetManager.get("PlayerFacingLeft");
+    }
+
+    if (direction && isDirectionRight(direction)) {
+      return this.assetManager.get("PlayerFacingRight");
+    }
+
+    if (direction && isDirectionDown(direction)) {
+      return this.assetManager.get("PlayerFacingDown");
+    }
+
+    if (direction && isDirectionUp(direction)) {
+      return this.assetManager.get("PlayerFacingUp");
+    }
+
+    return this.assetManager.get("PlayerFacingCenter");
   }
 
   getId(): string {
@@ -59,21 +87,22 @@ export class PlayerClient implements IClientEntity, Renderable, Positionable {
 
   render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
     const targetPosition = this.getPosition();
+    const image = this.getImage();
 
     this.lastRenderPosition.x += (targetPosition.x - this.lastRenderPosition.x) * this.LERP_FACTOR;
     this.lastRenderPosition.y += (targetPosition.y - this.lastRenderPosition.y) * this.LERP_FACTOR;
 
     const renderPosition = roundVector2(this.lastRenderPosition);
 
-    ctx.drawImage(this.image, renderPosition.x, renderPosition.y);
+    ctx.drawImage(image, renderPosition.x, renderPosition.y);
 
     const speed = Math.sqrt(this.velocity.x * this.velocity.x + this.velocity.y * this.velocity.y);
     if (speed > 0) {
       const direction = normalizeVector(this.velocity);
 
       const arrowStart = {
-        x: renderPosition.x + this.image.width / 2,
-        y: renderPosition.y + this.image.height / 2,
+        x: renderPosition.x + image.width / 2,
+        y: renderPosition.y + image.height / 2,
       };
 
       const arrowEnd = {

--- a/packages/game-client/src/entities/tree.ts
+++ b/packages/game-client/src/entities/tree.ts
@@ -6,21 +6,22 @@ import {
   Positionable,
   Vector2,
 } from "@survive-the-night/game-server";
-import { getEntityById, type GameState } from "../state";
+import { AssetManager } from "@/managers/asset";
+import { getEntityById, GameState } from "../state";
 import { IClientEntity, Renderable } from "./util";
 
 const TREE_SIZE = 16;
 
 export class TreeClient implements Renderable, Positionable, IClientEntity {
-  private image = new Image();
+  private assetManager: AssetManager;
   private type: EntityType;
   private id: string;
   private position: Vector2 = { x: 0, y: 0 };
 
-  constructor(id: string) {
+  constructor(id: string, assetManager: AssetManager) {
     this.id = id;
     this.type = Entities.TREE;
-    this.image.src = "/tree.png";
+    this.assetManager = assetManager;
   }
 
   getId(): string {
@@ -55,26 +56,18 @@ export class TreeClient implements Renderable, Positionable, IClientEntity {
   }
 
   render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
-    const myPlayer = getEntityById(gameState, gameState.playerId) as
-      | Positionable
-      | undefined;
+    const image = this.assetManager.get("Tree");
+    const myPlayer = getEntityById(gameState, gameState.playerId) as Positionable | undefined;
 
-    if (
-      myPlayer &&
-      distance(myPlayer.getPosition(), this.getPosition()) < HARVEST_DISTANCE
-    ) {
+    if (myPlayer && distance(myPlayer.getPosition(), this.getPosition()) < HARVEST_DISTANCE) {
       ctx.fillStyle = "white";
       ctx.font = "6px Arial";
       const text = "harvest (e)";
       const textWidth = ctx.measureText(text).width;
-      ctx.fillText(
-        text,
-        this.getCenterPosition().x - textWidth / 2,
-        this.getPosition().y - 3
-      );
+      ctx.fillText(text, this.getCenterPosition().x - textWidth / 2, this.getPosition().y - 3);
     }
 
-    ctx.drawImage(this.image, this.getPosition().x, this.getPosition().y);
+    ctx.drawImage(image, this.getPosition().x, this.getPosition().y);
 
     // hitbox
     // const serverPosition = roundVector2(targetPosition);

--- a/packages/game-client/src/entities/wall.ts
+++ b/packages/game-client/src/entities/wall.ts
@@ -1,19 +1,20 @@
 import { Entities, EntityType, Positionable, Vector2 } from "@survive-the-night/game-server";
-import { type GameState } from "../state";
+import { AssetManager } from "@/managers/asset";
+import { GameState } from "../state";
 import { IClientEntity, Renderable } from "./util";
 
 const WALL_SIZE = 16;
 
 export class WallClient implements Renderable, Positionable, IClientEntity {
-  private image = new Image();
+  private assetManager: AssetManager;
   private type: EntityType;
   private id: string;
   private position: Vector2 = { x: 0, y: 0 };
 
-  constructor(id: string) {
+  constructor(id: string, assetManager: AssetManager) {
     this.id = id;
     this.type = Entities.WALL;
-    this.image.src = "/wall.png";
+    this.assetManager = assetManager;
   }
 
   getId(): string {
@@ -48,6 +49,7 @@ export class WallClient implements Renderable, Positionable, IClientEntity {
   }
 
   render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
-    ctx.drawImage(this.image, this.getPosition().x, this.getPosition().y);
+    const image = this.assetManager.get("Wall");
+    ctx.drawImage(image, this.getPosition().x, this.getPosition().y);
   }
 }

--- a/packages/game-client/src/managers/asset.ts
+++ b/packages/game-client/src/managers/asset.ts
@@ -15,9 +15,12 @@ function assetMap({
 // sheet gaps: 1px horizontally, 3px vertically
 export const assetsMap = {
   PlayerFacingCenter: assetMap({ x: 493, y: 190 }),
+  PlayerFacingDown: assetMap({ x: 493, y: 190 }),
   PlayerFacingLeft: assetMap({ x: 493, y: 209, flipX: true }),
   PlayerFacingRight: assetMap({ x: 493, y: 209 }),
   PlayerFacingUp: assetMap({ x: 493, y: 171 }),
+  Tree: assetMap({ x: 221, y: 209 }),
+  Wall: assetMap({ x: 357, y: 95 }),
 } as const;
 
 export type Asset = keyof typeof assetsMap;
@@ -27,23 +30,35 @@ export const assetsCache = {} as Record<Asset, HTMLImageElement>;
 export class AssetManager {
   private imageManager = new ImageManager();
   private sheet: HTMLImageElement | null = null;
+  private loaded = false;
 
-  public async init(): Promise<void> {
+  public async load(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+
     if (this.sheet === null) {
       this.sheet = await this.imageManager.load("/tile-sheet.png");
     }
 
     await this.populateCache();
+    this.loaded = true;
   }
 
   public get(assetKey: Asset): HTMLImageElement {
-    return assetsCache[assetKey];
+    const asset = assetsCache[assetKey];
+    if (asset === undefined) {
+      throw new Error(
+        "Tried getting an asset without having it cached, make sure to call `.load()` first"
+      );
+    }
+    return asset;
   }
 
   public getSheet(): HTMLImageElement {
     if (this.sheet === null) {
       throw new Error(
-        "Tried getting a sheet without having it initialized, make sure to call `.init()` first"
+        "Tried getting a sheet without having it initialized, make sure to call `.load()` first"
       );
     }
 
@@ -55,8 +70,9 @@ export class AssetManager {
 
     await Promise.all(
       Object.keys(assetsMap).map(async (assetKey) => {
-        const cropOptions = assetsMap[assetKey as Asset];
-        await this.imageManager.crop(sheet, cropOptions);
+        const asset = assetKey as Asset;
+        const cropOptions = assetsMap[asset];
+        assetsCache[asset] = await this.imageManager.crop(sheet, cropOptions);
       })
     );
   }

--- a/packages/game-client/src/managers/image.ts
+++ b/packages/game-client/src/managers/image.ts
@@ -24,7 +24,7 @@ export class ImageManager {
       ctx.scale(-1, 1);
     }
 
-    ctx.drawImage(image, x, y, image.width, image.height, 0, 0, canvas.width, canvas.height);
+    ctx.drawImage(image, x, y, canvas.width, canvas.height, 0, 0, canvas.width, canvas.height);
 
     const url = canvas.toDataURL();
     return await this.load(url);

--- a/packages/game-server/src/shared/direction.ts
+++ b/packages/game-server/src/shared/direction.ts
@@ -14,7 +14,7 @@ export enum Direction {
 export function determineDirection(vector: Vector2): Direction | null {
   if (vector.x < 0 && vector.y > 0) {
     return Direction.DownLeft;
-  } else if (vector.x > 0 && vector.y < 0) {
+  } else if (vector.x > 0 && vector.y > 0) {
     return Direction.DownRight;
   } else if (vector.x < 0 && vector.y < 0) {
     return Direction.UpLeft;

--- a/packages/game-server/src/shared/direction.ts
+++ b/packages/game-server/src/shared/direction.ts
@@ -11,46 +11,62 @@ export enum Direction {
   UpRight,
 }
 
-export function determineDirection(vector: Vector2, fallback: Direction): Direction {
-  if (vector.x < 0 && vector.y < 0) {
+export function determineDirection(vector: Vector2): Direction | null {
+  if (vector.x < 0 && vector.y > 0) {
     return Direction.DownLeft;
   } else if (vector.x > 0 && vector.y < 0) {
     return Direction.DownRight;
-  } else if (vector.x < 0 && vector.y > 0) {
+  } else if (vector.x < 0 && vector.y < 0) {
     return Direction.UpLeft;
-  } else if (vector.x > 0 && vector.y > 0) {
+  } else if (vector.x > 0 && vector.y < 0) {
     return Direction.UpRight;
   }
 
-  if (vector.y < 0) {
+  if (vector.y > 0) {
     return Direction.Down;
   } else if (vector.x < 0) {
     return Direction.Left;
   } else if (vector.x > 0) {
     return Direction.Right;
-  } else if (vector.y > 0) {
+  } else if (vector.y < 0) {
     return Direction.Up;
   }
 
-  return fallback;
+  return null;
+}
+
+export function isDirectionDown(direction: Direction): boolean {
+  return [Direction.Down, Direction.DownLeft, Direction.DownRight].includes(direction);
+}
+
+export function isDirectionLeft(direction: Direction): boolean {
+  return [Direction.Left, Direction.DownLeft, Direction.UpLeft].includes(direction);
+}
+
+export function isDirectionRight(direction: Direction): boolean {
+  return [Direction.Right, Direction.DownRight, Direction.UpRight].includes(direction);
+}
+
+export function isDirectionUp(direction: Direction): boolean {
+  return [Direction.Up, Direction.UpLeft, Direction.UpRight].includes(direction);
 }
 
 export function normalizeDirection(direction: Direction): Vector2 {
   const result = { x: 0, y: 0 };
 
-  if ([Direction.Left, Direction.DownLeft, Direction.UpLeft].includes(direction)) {
+  if (isDirectionLeft(direction)) {
     result.x -= 1;
   }
 
-  if ([Direction.Down, Direction.DownLeft, Direction.DownRight].includes(direction)) {
+  if (isDirectionUp(direction)) {
     result.y -= 1;
   }
 
-  if ([Direction.Right, Direction.DownRight, Direction.UpRight].includes(direction)) {
+  if (isDirectionRight(direction)) {
     result.x += 1;
   }
 
-  if ([Direction.Up, Direction.UpLeft, Direction.UpRight].includes(direction)) {
+  if (isDirectionDown(direction)) {
     result.y += 1;
   }
 

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -74,7 +74,7 @@ export class Player extends Entity implements Facing, Movable, Positionable, Upd
   }
 
   handleAttack(deltaTime: number) {
-    this.facing = determineDirection(this.velocity, this.facing);
+    this.facing = determineDirection(this.velocity) ?? this.facing;
     this.fireCooldown -= deltaTime;
 
     if (this.input.fire && this.fireCooldown <= 0) {
@@ -91,25 +91,20 @@ export class Player extends Entity implements Facing, Movable, Positionable, Upd
   }
 
   handleMovement(deltaTime: number) {
-    const velocity = this.getVelocity();
-    const currentPosition = { ...this.getPosition() };
-    const previousPosition = { ...currentPosition };
+    const previousX = this.position.x;
+    const previousY = this.position.y;
 
-    // Try moving on X axis
-    currentPosition.x += velocity.x * deltaTime;
-    this.setPosition(currentPosition);
+    this.position.x += this.velocity.x * deltaTime;
+
     if (this.getEntityManager().isColliding(this)) {
-      currentPosition.x = previousPosition.x;
+      this.position.x = previousX;
     }
 
-    // Try moving on Y axis
-    currentPosition.y += velocity.y * deltaTime;
-    this.setPosition(currentPosition);
-    if (this.getEntityManager().isColliding(this)) {
-      currentPosition.y = previousPosition.y;
-    }
+    this.position.y += this.velocity.y * deltaTime;
 
-    this.setPosition(currentPosition);
+    if (this.getEntityManager().isColliding(this)) {
+      this.position.y = previousY;
+    }
   }
 
   update(deltaTime: number) {


### PR DESCRIPTION
- made loading GameClient async (because of async assets loading)
- moved startRender logic to `gameClient.start()`
- added `gameClient.stop()` <- automatically called on unmount
- for each client-entity added assetManager field
- player's facing direction is rendered with 5 assets (left, right, up, down, center)
- fixed determining direction from velocity (y=-1 - up and y=1 - down) [was added I thought it working vice versa]
- simplified handleMovement server function logic