### PR TITLE
Ability to craft recipes

### DIFF
--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -9,7 +9,7 @@ import { MapManager } from "./managers/map";
 import { TreeClient } from "./entities/tree";
 import { GameState, getEntityById } from "./state";
 import { IClientEntity, Renderable } from "./entities/util";
-import { HotbarClient } from "./ui/hotbar";
+import { Hotbar } from "./ui/hotbar";
 import { BulletClient } from "./entities/bullet";
 import { StorageManager } from "./managers/storage";
 import { WallClient } from "./entities/wall";
@@ -32,7 +32,7 @@ export class GameClient {
   private reqId: number | null = null;
   private running = false;
   private mounted = true;
-  private hotbar: HotbarClient;
+  private hotbar: Hotbar;
 
   constructor(serverUrl: string, canvas: HTMLCanvasElement) {
     this.ctx = canvas.getContext("2d")!;
@@ -48,7 +48,7 @@ export class GameClient {
     this.mapManager = new MapManager();
     this.hud = new Hud();
     this.inputManager = new InputManager();
-    this.hotbar = new HotbarClient(this.assetManager, this.inputManager, () => {
+    this.hotbar = new Hotbar(this.assetManager, this.inputManager, () => {
       if (this.gameState.playerId) {
         const player = getEntityById(
           this.gameState,

--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -10,6 +10,7 @@ import { TreeClient } from "./entities/tree";
 import { GameState, getEntityById } from "./state";
 import { IClientEntity, Renderable } from "./entities/util";
 import { Hotbar } from "./ui/hotbar";
+import { CraftingTable } from "./ui/crafting-table";
 import { BulletClient } from "./entities/bullet";
 import { StorageManager } from "./managers/storage";
 import { WallClient } from "./entities/wall";
@@ -27,6 +28,7 @@ export class GameClient {
   private latestEntities: EntityDto[] = [];
   private gameState: GameState;
   private hud: Hud;
+  private craftingTable: CraftingTable;
   private scale: number;
   private unmountQueue: Function[] = [];
   private reqId: number | null = null;
@@ -45,10 +47,7 @@ export class GameClient {
     this.cameraManager = new CameraManager(this.ctx);
     this.cameraManager.setScale(this.scale);
 
-    this.mapManager = new MapManager();
-    this.hud = new Hud();
-    this.inputManager = new InputManager();
-    this.hotbar = new Hotbar(this.assetManager, this.inputManager, () => {
+    const getInventory = () => {
       if (this.gameState.playerId) {
         const player = getEntityById(
           this.gameState,
@@ -60,7 +59,43 @@ export class GameClient {
       }
 
       return [];
+    };
+
+    this.mapManager = new MapManager();
+    this.hud = new Hud();
+
+    this.craftingTable = new CraftingTable(this.assetManager, {
+      getInventory,
+      onCraft: (recipe) => {
+        this.socketManager.sendCraftRequest(recipe);
+      },
     });
+
+    this.inputManager = new InputManager({
+      onCraft: () => {
+        this.craftingTable.toggle();
+      },
+      onDown: () => {
+        if (this.craftingTable.isVisible()) {
+          this.craftingTable.onDown();
+        }
+        return this.craftingTable.isVisible();
+      },
+      onFire: () => {
+        if (this.craftingTable.isVisible()) {
+          this.craftingTable.onSelect();
+        }
+        return this.craftingTable.isVisible();
+      },
+      onUp: () => {
+        if (this.craftingTable.isVisible()) {
+          this.craftingTable.onUp();
+        }
+        return this.craftingTable.isVisible();
+      },
+    });
+
+    this.hotbar = new Hotbar(this.assetManager, this.inputManager, getInventory);
 
     this.gameState = {
       startedAt: Date.now(),
@@ -296,5 +331,6 @@ export class GameClient {
 
     this.hotbar.render(this.ctx, this.gameState);
     this.hud.render(this.ctx, this.gameState);
+    this.craftingTable.render(this.ctx, this.gameState);
   }
 }

--- a/packages/game-client/src/managers/input.ts
+++ b/packages/game-client/src/managers/input.ts
@@ -1,6 +1,13 @@
 import { determineDirection, Direction } from "@survive-the-night/game-server";
 import { Input } from "@survive-the-night/game-server/src/server";
 
+export interface InputManagerOptions {
+  onCraft?: () => unknown;
+  onDown?: () => boolean;
+  onFire?: () => boolean;
+  onUp?: () => boolean;
+}
+
 export class InputManager {
   private hasChanged = false;
   private inputs: Input = {
@@ -21,17 +28,24 @@ export class InputManager {
     this.lastInputs = { ...this.inputs };
   }
 
-  constructor() {
+  constructor({ onCraft, onDown, onFire, onUp }: InputManagerOptions = {}) {
     window.addEventListener("keydown", (e) => {
       const eventKey = e.key.toLowerCase();
 
       switch (eventKey) {
+        case "q":
+          onCraft?.();
+          break;
         case "w":
-          this.inputs.dy = -1;
-          this.inputs.facing = Direction.Up;
+          if (!onUp?.()) {
+            this.inputs.dy = -1;
+            this.inputs.facing = Direction.Up;
+          }
           break;
         case "s":
-          this.inputs.dy = 1;
+          if (!onDown?.()) {
+            this.inputs.dy = 1;
+          }
           break;
         case "a":
           this.inputs.dx = -1;
@@ -43,7 +57,9 @@ export class InputManager {
           this.inputs.harvest = true;
           break;
         case " ":
-          this.inputs.fire = true;
+          if (!onFire?.()) {
+            this.inputs.fire = true;
+          }
           break;
         case "g":
           this.inputs.drop = true;

--- a/packages/game-client/src/managers/socket.ts
+++ b/packages/game-client/src/managers/socket.ts
@@ -1,5 +1,5 @@
 import { io, Socket } from "socket.io-client";
-import { Events, GameStateEvent, InventoryItem } from "@survive-the-night/game-server";
+import { Events, GameStateEvent, RecipeType } from "@survive-the-night/game-server";
 
 export type EntityDto = { id: string } & any;
 
@@ -36,6 +36,10 @@ export class SocketManager {
     this.socket.on("disconnect", () => {
       console.log("Disconnected from game server");
     });
+  }
+
+  public sendCraftRequest(recipe: RecipeType) {
+    this.socket.emit(Events.CRAFT_REQUEST, recipe);
   }
 
   public sendInput(input: { dx: number; dy: number; harvest: boolean; fire: boolean }) {

--- a/packages/game-client/src/ui/crafting-table.ts
+++ b/packages/game-client/src/ui/crafting-table.ts
@@ -1,0 +1,203 @@
+import { Direction, InventoryItem, recipes, RecipeType } from "@survive-the-night/game-server";
+import { Renderable } from "../entities/util";
+import { GameState } from "@/state";
+import { AssetManager, getItemAssetKey } from "../managers/asset";
+
+const CRAFTING_TABLE_SETTINGS = {
+  Container: {
+    background: "white",
+    padding: {
+      bottom: 20,
+      left: 20,
+      right: 20,
+      top: 20,
+    },
+    right: 20,
+  },
+  Recipes: {
+    gapX: 10,
+    gapY: 10,
+  },
+  Recipe: {
+    background: "gray",
+    borderColor: "gray",
+    borderWidth: 6,
+
+    active: {
+      borderColor: "green",
+    },
+    disabled: {
+      opacity: 50,
+    },
+  },
+  Slot: {
+    padding: {
+      bottom: 10,
+      left: 10,
+      right: 10,
+      top: 10,
+    },
+    size: 50,
+  },
+  Line: {
+    color: "black",
+    height: 8,
+    width: 25,
+  },
+};
+
+export interface CraftingTableOptions {
+  getInventory: () => InventoryItem[];
+  onCraft: (recipe: RecipeType) => unknown;
+}
+
+export class CraftingTable implements Renderable {
+  private assetManager: AssetManager;
+  private activeRecipe = 0;
+  private visible = false;
+  private getInventory: () => InventoryItem[];
+  private onCraft: (recipe: RecipeType) => unknown;
+
+  public constructor(assetManager: AssetManager, { getInventory, onCraft }: CraftingTableOptions) {
+    this.assetManager = assetManager;
+    this.getInventory = getInventory;
+    this.onCraft = onCraft;
+  }
+
+  public onDown() {
+    this.activeRecipe += 1;
+
+    if (this.activeRecipe === recipes.length) {
+      this.activeRecipe = 0;
+    }
+  }
+
+  public onSelect() {
+    this.onCraft(recipes[this.activeRecipe].getType());
+  }
+
+  public onUp() {
+    this.activeRecipe -= 1;
+
+    if (this.activeRecipe === -1) {
+      this.activeRecipe = recipes.length - 1;
+    }
+  }
+
+  public isVisible() {
+    return this.visible;
+  }
+
+  public render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
+    if (!this.visible) {
+      return;
+    }
+
+    const { Container, Line, Recipe, Recipes, Slot } = CRAFTING_TABLE_SETTINGS;
+    let maxRecipeWidth = 0;
+
+    for (const recipe of recipes) {
+      // plus one for the resulting component
+      const componentsAmount = recipe.components().length + 1;
+
+      const recipeWidth =
+        componentsAmount * Slot.size +
+        (componentsAmount + 1) * Recipes.gapX +
+        Line.width +
+        Recipe.borderWidth * 2;
+
+      if (recipeWidth > maxRecipeWidth) {
+        maxRecipeWidth = recipeWidth;
+      }
+    }
+
+    const { height: screenHeight, width: screenWidth } = ctx.canvas;
+    const width = Container.padding.left + maxRecipeWidth + Container.padding.right;
+
+    const height =
+      Container.padding.top +
+      (Slot.size + Recipe.borderWidth * 2) * recipes.length +
+      Recipes.gapY * (recipes.length - 1) +
+      Container.padding.bottom;
+
+    const offsetTop = screenHeight / 2 - height / 2;
+    const offsetLeft = screenWidth - width - Container.right;
+
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    ctx.fillStyle = Container.background;
+    ctx.fillRect(offsetLeft, offsetTop, width, height);
+
+    for (let i = 0; i < recipes.length; i++) {
+      const recipe = recipes[i];
+      const disabled = !recipe.canBeCrafted(this.getInventory());
+      const components = recipe.components();
+      const resulting = recipe.resultingComponent();
+
+      ctx.globalAlpha = disabled ? Recipe.disabled.opacity / 100 : 1;
+
+      let recipeHeight = Slot.size + Recipe.borderWidth * 2;
+      let recipeWidth = maxRecipeWidth;
+      let recipeOffsetTop = offsetTop + Container.padding.top + i * recipeHeight + i * Recipes.gapY;
+      let recipeOffsetLeft = offsetLeft + Container.padding.left;
+
+      // draw recipe border
+      ctx.fillStyle = i === this.activeRecipe ? Recipe.active.borderColor : Recipe.borderColor;
+      ctx.fillRect(recipeOffsetLeft, recipeOffsetTop, recipeWidth, recipeHeight);
+
+      recipeOffsetTop += Recipe.borderWidth;
+      recipeOffsetLeft += Recipe.borderWidth;
+
+      recipeHeight -= Recipe.borderWidth * 2;
+      recipeWidth -= Recipe.borderWidth * 2;
+
+      // draw recipe background
+      ctx.fillStyle = Recipe.background;
+      ctx.fillRect(recipeOffsetLeft, recipeOffsetTop, recipeWidth, recipeHeight);
+
+      const slotWidth = Slot.size - Slot.padding.left - Slot.padding.right;
+      const slotHeight = Slot.size - Slot.padding.top - Slot.padding.bottom;
+      const slotTop = recipeOffsetTop + Slot.padding.top;
+      let slotLeft = recipeOffsetLeft;
+
+      for (const component of components) {
+        slotLeft += Slot.padding.left;
+
+        const slotImage = this.assetManager.getWithDirection(
+          getItemAssetKey({ key: component.type }),
+          Direction.Right
+        );
+
+        // draw each individual crafting component
+        ctx.drawImage(slotImage, slotLeft, slotTop, slotWidth, slotHeight);
+        slotLeft += slotWidth + Slot.padding.right + Recipes.gapX;
+      }
+
+      const lineOffsetTop = slotTop + (slotHeight - Line.height) / 2;
+
+      // draw line
+      ctx.fillStyle = Line.color;
+      ctx.fillRect(slotLeft, lineOffsetTop, Line.width, Line.height);
+
+      slotLeft += Line.width + Recipes.gapX + Slot.padding.left;
+
+      const slotImage = this.assetManager.getWithDirection(
+        getItemAssetKey({ key: resulting.type }),
+        Direction.Right
+      );
+
+      // draw resulting component
+      ctx.drawImage(slotImage, slotLeft, slotTop, slotWidth, slotHeight);
+
+      ctx.globalAlpha = 1;
+    }
+
+    ctx.restore();
+  }
+
+  public toggle(): void {
+    this.visible = !this.visible;
+    this.activeRecipe = 0;
+  }
+}

--- a/packages/game-client/src/ui/hotbar.ts
+++ b/packages/game-client/src/ui/hotbar.ts
@@ -23,7 +23,7 @@ const HOTBAR_SETTINGS = {
   },
 };
 
-export class HotbarClient implements Renderable {
+export class Hotbar implements Renderable {
   private assetManager: AssetManager;
   private inputManager: InputManager;
   private getInventory: () => InventoryItem[];

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -1,5 +1,24 @@
 import { GameState } from "../state";
 
+const HUD_SETTINGS = {
+  ControlsList: {
+    innerText: "Harvest [E]\nCraft [Q]\nLeft [A]\nRight [D]\nDown [S]\nUp [W]",
+
+    background: "rgba(0, 0, 0, 0.8)",
+    color: "rgb(255, 255, 255)",
+    font: "32px Arial",
+    lineHeight: 40,
+    left: 20,
+    top: 20,
+    padding: {
+      bottom: 20,
+      left: 20,
+      right: 20,
+      top: 20,
+    },
+  },
+};
+
 export class Hud {
   constructor() {}
 
@@ -23,5 +42,64 @@ export class Hud {
     const gap = 50;
     ctx.fillText(dayText, width - dayTextWidth - margin, margin);
     ctx.fillText(cycleText, width - cycleTextWidth - margin, margin + gap);
+
+    this.renderControlsList(ctx);
+  }
+
+  public renderControlsList(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    ctx.font = HUD_SETTINGS.ControlsList.font;
+
+    const lines = HUD_SETTINGS.ControlsList.innerText.split("\n");
+    let maxLineWidth = 0;
+    let maxLineHeight = 0;
+
+    for (const line of lines) {
+      const metrics = ctx.measureText(line);
+
+      if (maxLineWidth < metrics.width) {
+        maxLineWidth = metrics.width;
+      }
+
+      if (maxLineHeight < metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent) {
+        maxLineHeight = metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
+      }
+    }
+
+    const lineHeight =
+      HUD_SETTINGS.ControlsList.lineHeight > maxLineHeight
+        ? HUD_SETTINGS.ControlsList.lineHeight
+        : maxLineHeight;
+
+    const height =
+      lineHeight * lines.length +
+      HUD_SETTINGS.ControlsList.padding.top +
+      HUD_SETTINGS.ControlsList.padding.bottom;
+
+    const width =
+      maxLineWidth +
+      HUD_SETTINGS.ControlsList.padding.left +
+      HUD_SETTINGS.ControlsList.padding.right;
+
+    ctx.fillStyle = HUD_SETTINGS.ControlsList.background;
+    ctx.fillRect(HUD_SETTINGS.ControlsList.left, HUD_SETTINGS.ControlsList.top, width, height);
+
+    ctx.textBaseline = "top";
+    ctx.fillStyle = HUD_SETTINGS.ControlsList.color;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const offsetTop = i * lineHeight + (HUD_SETTINGS.ControlsList.lineHeight - maxLineHeight) / 2;
+
+      ctx.fillText(
+        line,
+        HUD_SETTINGS.ControlsList.left + HUD_SETTINGS.ControlsList.padding.left,
+        offsetTop + HUD_SETTINGS.ControlsList.top + HUD_SETTINGS.ControlsList.padding.top
+      );
+    }
+
+    ctx.restore();
   }
 }

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -2,7 +2,19 @@ import { GameState } from "../state";
 
 const HUD_SETTINGS = {
   ControlsList: {
-    innerText: "Harvest [E]\nCraft [Q]\nLeft [A]\nRight [D]\nDown [S]\nUp [W]",
+    innerText:
+      "Harvest [E]\n" +
+      "Craft [Q]\n" +
+      "Left [A]\n" +
+      "Right [D]\n" +
+      "Down [S]\n" +
+      "Up [W]\n" +
+      "Fire [SPACE]\n" +
+      "\n" +
+      "When Crafting:\n" +
+      "Down [S]\n" +
+      "Up [W]\n" +
+      "Craft [SPACE]",
 
     background: "rgba(0, 0, 0, 0.8)",
     color: "rgb(255, 255, 255)",

--- a/packages/game-server/src/index.ts
+++ b/packages/game-server/src/index.ts
@@ -4,6 +4,7 @@ export * from "./shared/entities/player";
 export * from "./shared/entities/weapon";
 export * from "./shared/events";
 export * from "./shared/inventory";
+export * from "./shared/recipes";
 export * from "./shared/traits";
 export * from "./shared/direction";
 

--- a/packages/game-server/src/managers/socket-manager.ts
+++ b/packages/game-server/src/managers/socket-manager.ts
@@ -5,6 +5,7 @@ import { EntityManager } from "./entity-manager";
 import { MapManager } from "./map-manager";
 import { Input } from "../server";
 import { Player } from "../shared/entities/player";
+import { RecipeType } from "@/shared/recipes";
 
 export class SocketManager {
   private io: Server;
@@ -41,6 +42,14 @@ export class SocketManager {
     }
   }
 
+  private onCraftRequest(socket: Socket, recipe: RecipeType): void {
+    const player = this.players.get(socket.id);
+
+    if (player) {
+      player.craftRecipe(recipe);
+    }
+  }
+
   private onPlayerInput(socket: Socket, input: Input): void {
     const player = this.players.get(socket.id);
 
@@ -67,6 +76,7 @@ export class SocketManager {
     socket.emit(Events.YOUR_ID, player.getId());
 
     socket.on("playerInput", (input: Input) => this.onPlayerInput(socket, input));
+    socket.on(Events.CRAFT_REQUEST, (recipe: RecipeType) => this.onCraftRequest(socket, recipe));
 
     socket.on("disconnect", () => {
       this.onDisconnect(socket);

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -10,6 +10,7 @@ import { normalizeVector, Vector2 } from "../physics";
 import { Direction } from "../direction";
 import { InventoryItem, ItemType } from "../inventory";
 import { Weapon } from "./weapon";
+import { recipes, RecipeType } from "../recipes";
 
 export const FIRE_COOLDOWN = 0.4;
 export const MAX_INVENTORY_SLOTS = 8;
@@ -113,6 +114,16 @@ export class Player extends Entity implements Movable, Positionable, Updatable, 
 
   setPosition(position: Vector2) {
     this.position = position;
+  }
+
+  craftRecipe(recipe: RecipeType): void {
+    const foundRecipe = recipes.find((it) => it.getType() === recipe);
+
+    if (foundRecipe === undefined) {
+      return;
+    }
+
+    this.inventory = foundRecipe.craft(this.inventory);
   }
 
   handleAttack(deltaTime: number) {

--- a/packages/game-server/src/shared/events.ts
+++ b/packages/game-server/src/shared/events.ts
@@ -1,6 +1,7 @@
 import { RawEntity } from "./entities";
 
 export const Events = {
+  CRAFT_REQUEST: "craftRequest",
   GAME_STATE_UPDATE: "gameState",
   PLAYER_INPUT: "playerInput",
   MAP: "map",

--- a/packages/game-server/src/shared/recipes.ts
+++ b/packages/game-server/src/shared/recipes.ts
@@ -1,0 +1,73 @@
+import { InventoryItem, ItemType } from "./inventory";
+import { WallRecipe } from "./recipes/wall-recipe";
+
+export enum RecipeType {
+  Wall = "wall",
+}
+
+export const recipes: Recipe[] = [
+  // added multiple same here so can test arrows up/down
+  new WallRecipe(),
+  new WallRecipe(),
+  new WallRecipe(),
+  new WallRecipe(),
+  new WallRecipe(),
+];
+
+export interface RecipeComponent {
+  type: ItemType;
+}
+
+export interface Recipe {
+  getType(): RecipeType;
+  canBeCrafted: (inventory: InventoryItem[]) => boolean;
+  components: () => RecipeComponent[];
+  craft: (inventory: InventoryItem[]) => InventoryItem[];
+  resultingComponent: () => RecipeComponent;
+}
+
+export function craftRecipe(recipe: Recipe, inventory: InventoryItem[]): InventoryItem[] {
+  const newInventory: InventoryItem[] = [];
+  const components = recipe.components();
+  const found: number[] = [];
+
+  for (const item of inventory) {
+    const componentIdx = components.findIndex(
+      (it, idx) => it.type === item.key && !found.includes(idx)
+    );
+
+    if (componentIdx === -1) {
+      newInventory.push(item);
+      continue;
+    }
+
+    found.push(componentIdx);
+  }
+
+  if (found.length !== components.length) {
+    return inventory;
+  }
+
+  const resulting = recipe.resultingComponent();
+  newInventory.push({ key: resulting.type });
+  return newInventory;
+}
+
+export function recipeCanBeCrafted(recipe: Recipe, inventory: InventoryItem[]): boolean {
+  const components = recipe.components();
+  const found: number[] = [];
+
+  for (const item of inventory) {
+    const componentIdx = components.findIndex(
+      (it, idx) => it.type === item.key && !found.includes(idx)
+    );
+
+    if (componentIdx === -1) {
+      continue;
+    }
+
+    found.push(componentIdx);
+  }
+
+  return found.length === components.length;
+}

--- a/packages/game-server/src/shared/recipes/wall-recipe.ts
+++ b/packages/game-server/src/shared/recipes/wall-recipe.ts
@@ -1,0 +1,36 @@
+import { InventoryItem } from "../inventory";
+import { craftRecipe, Recipe, recipeCanBeCrafted, RecipeComponent, RecipeType } from "../recipes";
+
+export class WallRecipe implements Recipe {
+  public getType(): RecipeType {
+    return RecipeType.Wall;
+  }
+
+  public canBeCrafted(inventory: InventoryItem[]): boolean {
+    return recipeCanBeCrafted(this, inventory);
+  }
+
+  public components(): RecipeComponent[] {
+    return [
+      {
+        type: "Wood",
+      },
+      {
+        type: "Wood",
+      },
+      {
+        type: "Wood",
+      },
+    ];
+  }
+
+  public craft(inventory: InventoryItem[]): InventoryItem[] {
+    return craftRecipe(this, inventory);
+  }
+
+  public resultingComponent(): RecipeComponent {
+    return {
+      type: "Wall",
+    };
+  }
+}


### PR DESCRIPTION
- added controls list to the top left
<img width="444" alt="image" src="https://github.com/user-attachments/assets/cb5836f5-c602-46ef-80f8-2fa266d00523">

- added ability to craft. The idea: you can craft a recipe if you have all the needed crafting components in your inventory. If you don't have them - you can't craft it.

you obtain needed amount of components for crafting:
<img width="902" alt="Screenshot 2024-12-05 at 3 24 35 AM" src="https://github.com/user-attachments/assets/dbd8243e-a578-4360-9485-13dd84f78034">

you click Q and then crafting table pops up
<img width="898" alt="Screenshot 2024-12-05 at 3 25 24 AM" src="https://github.com/user-attachments/assets/633211d0-ee1e-421b-8f70-6b418ed5de8f">

you select crafting recipe, hit Space and it will replace crafting components with a recipe you selected. recipes that can't be crafted become disabled.
<img width="898" alt="Screenshot 2024-12-05 at 3 26 03 AM" src="https://github.com/user-attachments/assets/93535e73-199d-426f-9020-371061ed067b">

you can then select crafted item and use it
<img width="898" alt="image" src="https://github.com/user-attachments/assets/8e188b95-5f85-48dd-8be5-d7b375959a2b">

gameplay
![Screen Recording 2024-12-05 at 3 37 32 AM](https://github.com/user-attachments/assets/2e67b4d9-30ff-471d-b8fd-a4b6eda7fd03)
