### PR TITLE
Minor improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,6 @@ Feel free to pick any item listed out here to work on.
 ### Bugs
 
 - [ ] when DEBUG = true, all the HUD overlays seem to shift, including the "pickup (e)" text over items
-- [ ] when a player is killed by a zombie, it seems like the zombie gets stuck either on the player, or thinks it still needs to attack the player.... debug this
 
 ### Gameplay
 
@@ -80,6 +79,8 @@ Feel free to pick any item listed out here to work on.
 - [ ] a player can chat with other players in their game via text
 - [ ] a user shall be able to see stamina bar which recharges slowly over time
 - [ ] a user shall be able to run using shift
+- [ ] zombie never stops walking, even when killed all players
+- [ ] person hosting game server should be able to login as admin in console and have ability to ban/kick/teleport players (by Aaron)
 
 ## Low Priority (Polish):
 
@@ -129,3 +130,4 @@ Feel free to pick any item listed out here to work on.
 - [x] the crafting recipe should be red or grayed out if you don't have enough items to craft it
 - [x] pressing space while crafting an item you don't have enough resources to craft should not auto close the crafting menu
 - [x] zombie should use walk animation as well
+- [x] when a player is killed by a zombie, it seems like the zombie gets stuck either on the player, or thinks it still needs to attack the player

--- a/TODO.md
+++ b/TODO.md
@@ -15,12 +15,10 @@ Feel free to pick any item listed out here to work on.
 ### Bugs
 
 - [ ] when DEBUG = true, all the HUD overlays seem to shift, including the "pickup (e)" text over items
-- [ ] every player faces the same direction as YOUR player which is a bug
 - [ ] when a player is killed by a zombie, it seems like the zombie gets stuck either on the player, or thinks it still needs to attack the player.... debug this
 
 ### Crafting
 
-- [ ] the crafting recipe should be red or grayed out if you don't have enough items to craft it
 - [ ] pressing space while crafting an item you don't have enough resources to craft should not auto close the crafting menu
 
 ### Gameplay
@@ -146,3 +144,5 @@ Feel free to pick any item listed out here to work on.
 - [x] a player shouldn't be able to open the craft menu when dead; also close it if they die while crafting
 - [x] a player should drop all items when they die and scatter them around their body
 - [x] the player should have a running animation (keep it simple), 2 frames with legs going up and down
+- [x] every player faces the same direction as YOUR player which is a bug
+- [x] the crafting recipe should be red or grayed out if you don't have enough items to craft it

--- a/TODO.md
+++ b/TODO.md
@@ -19,8 +19,6 @@ Feel free to pick any item listed out here to work on.
 
 ### Crafting
 
-- [ ] pressing space while crafting an item you don't have enough resources to craft should not auto close the crafting menu
-
 ### Gameplay
 
 - [ ] zombie should use walk animation as well
@@ -146,3 +144,4 @@ Feel free to pick any item listed out here to work on.
 - [x] the player should have a running animation (keep it simple), 2 frames with legs going up and down
 - [x] every player faces the same direction as YOUR player which is a bug
 - [x] the crafting recipe should be red or grayed out if you don't have enough items to craft it
+- [x] pressing space while crafting an item you don't have enough resources to craft should not auto close the crafting menu

--- a/TODO.md
+++ b/TODO.md
@@ -17,11 +17,8 @@ Feel free to pick any item listed out here to work on.
 - [ ] when DEBUG = true, all the HUD overlays seem to shift, including the "pickup (e)" text over items
 - [ ] when a player is killed by a zombie, it seems like the zombie gets stuck either on the player, or thinks it still needs to attack the player.... debug this
 
-### Crafting
-
 ### Gameplay
 
-- [ ] zombie should use walk animation as well
 - [ ] during daytime, zombies should just wander around randomly, but will attack players if they get close
 - [ ] if ALL players die, the game ends
 - [ ] show a message that the players lost, and show a leaderboard with how many kills each player got
@@ -51,8 +48,10 @@ Feel free to pick any item listed out here to work on.
 - [ ] add sound for zombie hurt
 - [ ] add sound for zombie attack
 - [ ] add sound for item pickup
+- [ ] add sound for item craft
 - [ ] add sound for item drop
 - [ ] add sound for player death
+- [ ] ambient background music that can be turned off
 
 ### Lobby
 
@@ -68,22 +67,6 @@ Feel free to pick any item listed out here to work on.
 - [ ] create a "city" zone which has a building and roads
 - [ ] create a "road" zone which is used to connect cities and farms (road going up or down)
 - [ ] generate larger maps containing farms, cities, and roads that connect them.
-
-### Game Feel
-
-- [ ] the zombies need running animations as well
-- [ ] need sound effects for
-  - [ ] zombie attacking
-  - [ ] zombie dying
-  - [ ] zombie walking
-  - [ ] player dying
-  - [ ] player attacking
-  - [ ] player shooting
-  - [ ] player walking
-  - [ ] new items crafted
-  - [ ] items picked up
-  - [ ] items dropped
-  - [ ] ambient background music that can be turned off
 
 ## Medium Priority (Enhancements):
 
@@ -145,3 +128,4 @@ Feel free to pick any item listed out here to work on.
 - [x] every player faces the same direction as YOUR player which is a bug
 - [x] the crafting recipe should be red or grayed out if you don't have enough items to craft it
 - [x] pressing space while crafting an item you don't have enough resources to craft should not auto close the crafting menu
+- [x] zombie should use walk animation as well

--- a/packages/dashboard/.env.example
+++ b/packages/dashboard/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_WEBSOCKET_URL=http://localhost:3001

--- a/packages/dashboard/.gitignore
+++ b/packages/dashboard/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -134,11 +134,13 @@ export class GameClient {
           return;
         }
 
-        this.craftingTable.toggle();
-        if (this.craftingTable.isVisible()) {
-          this.socketManager.sendStopCrafting();
-        } else {
+        this.craftingTable.reset();
+        this.gameState.crafting = !this.craftingTable.isVisible();
+
+        if (this.gameState.crafting) {
           this.socketManager.sendStartCrafting();
+        } else {
+          this.socketManager.sendStopCrafting();
         }
       },
       onDown: (inputs: Input) => {
@@ -194,6 +196,7 @@ export class GameClient {
       dayNumber: 0,
       untilNextCycle: 0,
       isDay: true,
+      crafting: false,
     };
 
     this.socketManager = new SocketManager(serverUrl, {

--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -1,7 +1,14 @@
 import { AssetManager } from "./managers/asset";
 import { InputManager } from "./managers/input";
 import { EntityDto, SocketManager } from "./managers/socket";
-import { Entities, EntityType, GameStateEvent, Positionable } from "@survive-the-night/game-server";
+import {
+  Direction,
+  Entities,
+  EntityType,
+  GameStateEvent,
+  Input,
+  Positionable,
+} from "@survive-the-night/game-server";
 import { PlayerClient } from "./entities/player";
 import { ZombieClient } from "./entities/zombie";
 import { CameraManager } from "./managers/camera";
@@ -16,7 +23,6 @@ import { StorageManager } from "./managers/storage";
 import { WallClient } from "./entities/wall";
 import { Hud } from "./ui/hud";
 import { WeaponClient } from "./entities/weapon";
-import { Input } from "@survive-the-night/game-server/src/server";
 import { BandageClient } from "./entities/items/bandage";
 import { SoundClient } from "./entities/sound";
 
@@ -41,7 +47,7 @@ export class GameClient {
 
   private entityFactories: Record<EntityType, (entityData: EntityDto) => IClientEntity> = {
     [Entities.PLAYER]: (data) => {
-      const entity = new PlayerClient(data.id, this.assetManager, this.inputManager);
+      const entity = new PlayerClient(data.id, this.assetManager);
       this.initializeEntity(entity, data);
       return entity;
     },
@@ -123,6 +129,7 @@ export class GameClient {
       getPlayer,
       onCraft: (recipe) => {
         this.socketManager.sendCraftRequest(recipe);
+        this.gameState.crafting = false;
       },
     });
 
@@ -148,16 +155,19 @@ export class GameClient {
           this.craftingTable.onDown();
         } else {
           inputs.dy = 1;
+          inputs.facing = Direction.Down;
         }
       },
       onRight: (inputs: Input) => {
         if (!this.craftingTable.isVisible()) {
           inputs.dx = 1;
+          inputs.facing = Direction.Right;
         }
       },
       onLeft: (inputs: Input) => {
         if (!this.craftingTable.isVisible()) {
           inputs.dx = -1;
+          inputs.facing = Direction.Left;
         }
       },
       onInteract: (inputs: Input) => {
@@ -183,6 +193,7 @@ export class GameClient {
           this.craftingTable.onUp();
         } else {
           inputs.dy = -1;
+          inputs.facing = Direction.Up;
         }
       },
     });
@@ -219,7 +230,7 @@ export class GameClient {
     await this.assetManager.load();
   }
 
-  public sendInput(input: { dx: number; dy: number; interact: boolean; fire: boolean }): void {
+  public sendInput(input: Input): void {
     this.socketManager.sendInput(input);
   }
 

--- a/packages/game-client/src/entities/zombie.ts
+++ b/packages/game-client/src/entities/zombie.ts
@@ -99,13 +99,18 @@ export class ZombieClient implements IClientEntity, Renderable, Positionable, Da
       duration: 500,
       frames: 3,
     });
-    const image = this.assetManager.getFrameWithDirection("Zombie", facing, frameIndex);
+
+    const image = this.isDead()
+      ? this.assetManager.get("ZombieDead")
+      : this.assetManager.getFrameWithDirection("Zombie", facing, frameIndex);
 
     ctx.drawImage(image, renderPosition.x, renderPosition.y);
 
-    drawHealthBar(ctx, renderPosition, this.health, this.getMaxHealth());
+    if (!this.isDead()) {
+      drawHealthBar(ctx, renderPosition, this.health, this.getMaxHealth());
 
-    debugDrawHitbox(ctx, Zombie.getHitbox(this.position));
-    debugDrawHitbox(ctx, Zombie.getDamageBox(this.position), "red");
+      debugDrawHitbox(ctx, Zombie.getHitbox(this.position));
+      debugDrawHitbox(ctx, Zombie.getDamageBox(this.position), "red");
+    }
   }
 }

--- a/packages/game-client/src/managers/asset.ts
+++ b/packages/game-client/src/managers/asset.ts
@@ -103,6 +103,7 @@ export const assetsMap = {
   Tree: assetMap({ x: 221, y: 209 }),
   Wall: assetMap({ x: 357, y: 95 }),
   Zombie: assetMap({ x: 493, y: 76 }),
+  ZombieDead: assetMap({ x: 289, y: 19 }),
   ZombieFacingDown: assetMap(zombieDownFrameOrigins[0]),
   ZombieFacingDown0: assetMap(zombieDownFrameOrigins[0]),
   ZombieFacingDown1: assetMap(zombieDownFrameOrigins[1]),

--- a/packages/game-client/src/managers/input.ts
+++ b/packages/game-client/src/managers/input.ts
@@ -1,5 +1,4 @@
-import { determineDirection, Direction } from "@survive-the-night/game-server";
-import { Input } from "@survive-the-night/game-server/src/server";
+import { determineDirection, Direction, Input } from "@survive-the-night/game-server";
 
 export interface InputManagerOptions {
   onCraft?: () => unknown;

--- a/packages/game-client/src/managers/socket.ts
+++ b/packages/game-client/src/managers/socket.ts
@@ -1,5 +1,5 @@
 import { io, Socket } from "socket.io-client";
-import { Events, GameStateEvent, RecipeType } from "@survive-the-night/game-server";
+import { Events, GameStateEvent, Input, RecipeType } from "@survive-the-night/game-server";
 
 export type EntityDto = { id: string } & any;
 
@@ -50,13 +50,7 @@ export class SocketManager {
     this.socket.emit(Events.STOP_CRAFTING);
   }
 
-  public sendInput(input: {
-    dx: number;
-    dy: number;
-    interact: boolean;
-    fire: boolean;
-    consume: boolean;
-  }) {
+  public sendInput(input: Input) {
     this.socket.emit(Events.PLAYER_INPUT, input);
   }
 }

--- a/packages/game-client/src/state.ts
+++ b/packages/game-client/src/state.ts
@@ -7,6 +7,7 @@ export type GameState = {
   dayNumber: number;
   untilNextCycle: number;
   isDay: boolean;
+  crafting: boolean;
 };
 
 export function getEntityById(gameState: GameState, id: string): Entity | undefined {

--- a/packages/game-client/src/ui/crafting-table.ts
+++ b/packages/game-client/src/ui/crafting-table.ts
@@ -79,7 +79,11 @@ export class CraftingTable implements Renderable {
   }
 
   public onSelect() {
-    this.onCraft(recipes[this.activeRecipe].getType());
+    const recipe = recipes[this.activeRecipe];
+
+    if (recipe.canBeCrafted(this.getInventory())) {
+      this.onCraft(recipe.getType());
+    }
   }
 
   public onUp() {

--- a/packages/game-client/src/ui/crafting-table.ts
+++ b/packages/game-client/src/ui/crafting-table.ts
@@ -28,7 +28,7 @@ const CRAFTING_TABLE_SETTINGS = {
       borderColor: "green",
     },
     disabled: {
-      opacity: 50,
+      background: "#F07878",
     },
   },
   Slot: {
@@ -141,8 +141,6 @@ export class CraftingTable implements Renderable {
       const components = recipe.components();
       const resulting = recipe.resultingComponent();
 
-      ctx.globalAlpha = disabled ? Recipe.disabled.opacity / 100 : 1;
-
       let recipeHeight = Slot.size + Recipe.borderWidth * 2;
       let recipeWidth = maxRecipeWidth;
       let recipeOffsetTop = offsetTop + Container.padding.top + i * recipeHeight + i * Recipes.gapY;
@@ -159,7 +157,7 @@ export class CraftingTable implements Renderable {
       recipeWidth -= Recipe.borderWidth * 2;
 
       // draw recipe background
-      ctx.fillStyle = Recipe.background;
+      ctx.fillStyle = disabled ? Recipe.disabled.background : Recipe.background;
       ctx.fillRect(recipeOffsetLeft, recipeOffsetTop, recipeWidth, recipeHeight);
 
       const slotWidth = Slot.size - Slot.padding.left - Slot.padding.right;
@@ -195,8 +193,6 @@ export class CraftingTable implements Renderable {
 
       // draw resulting component
       ctx.drawImage(slotImage, slotLeft, slotTop, slotWidth, slotHeight);
-
-      ctx.globalAlpha = 1;
     }
 
     ctx.restore();

--- a/packages/game-client/src/ui/crafting-table.ts
+++ b/packages/game-client/src/ui/crafting-table.ts
@@ -202,7 +202,7 @@ export class CraftingTable implements Renderable {
     ctx.restore();
   }
 
-  public toggle(): void {
+  public reset(): void {
     // this.visible = !this.visible;
     this.activeRecipe = 0;
   }

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -3,21 +3,6 @@ import { GameState, getEntityById } from "../state";
 
 const HUD_SETTINGS = {
   ControlsList: {
-    innerText:
-      "Harvest [E]\n" +
-      "Craft [Q]\n" +
-      "Left [A]\n" +
-      "Right [D]\n" +
-      "Down [S]\n" +
-      "Up [W]\n" +
-      "Fire [SPACE]\n" +
-      "Consume [F]\n" +
-      "\n" +
-      "When Crafting:\n" +
-      "Down [S]\n" +
-      "Up [W]\n" +
-      "Craft [SPACE]",
-
     background: "rgba(0, 0, 0, 0.8)",
     color: "rgb(255, 255, 255)",
     font: "32px Arial",
@@ -66,16 +51,29 @@ export class Hud {
       ctx.fillText(healthText, width - healthTextWidth - margin, margin + gap * 2);
     }
 
-    this.renderControlsList(ctx);
+    this.renderControlsList(ctx, gameState);
   }
 
-  public renderControlsList(ctx: CanvasRenderingContext2D): void {
+  public renderControlsList(ctx: CanvasRenderingContext2D, gameState: GameState): void {
+    const regularText =
+      "Left [A]\n" +
+      "Right [D]\n" +
+      "Down [S]\n" +
+      "Up [W]\n" +
+      "Fire [SPACE]\n" +
+      "Consume [F]\n" +
+      "Harvest [E]\n" +
+      "Craft [Q]\n";
+
+    const craftingText = "Down [S]\nUp [W]\nCraft [SPACE]";
+    const innerText = gameState.crafting ? craftingText : regularText;
+
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
 
     ctx.font = HUD_SETTINGS.ControlsList.font;
 
-    const lines = HUD_SETTINGS.ControlsList.innerText.split("\n");
+    const lines = innerText.trim().split("\n");
     let maxLineWidth = 0;
     let maxLineHeight = 0;
 

--- a/packages/game-server/src/index.ts
+++ b/packages/game-server/src/index.ts
@@ -7,5 +7,6 @@ export * from "./shared/inventory";
 export * from "./shared/recipes";
 export * from "./shared/traits";
 export * from "./shared/direction";
+export * from "./shared/input";
 
 export const DEBUG = false;

--- a/packages/game-server/src/server.ts
+++ b/packages/game-server/src/server.ts
@@ -1,21 +1,9 @@
-import { Direction } from "./shared/direction";
 import { GameStateEvent } from "./shared/events";
 import { EntityManager } from "./managers/entity-manager";
 import { MapManager } from "./managers/map-manager";
 import { SocketManager } from "./managers/socket-manager";
 
 export const FPS = 30;
-
-export type Input = {
-  facing: Direction;
-  dx: number;
-  dy: number;
-  interact: boolean;
-  fire: boolean;
-  inventoryItem: number;
-  drop: boolean;
-  consume: boolean;
-};
 
 export const DAY_DURATION = 300;
 export const NIGHT_DURATION = 30;

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -120,6 +120,7 @@ export class Player
   onDeath(): void {
     this.setIsCrafting(false);
     this.scatterInventory();
+    this.inventory = [];
   }
 
   scatterInventory(): void {

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -256,7 +256,7 @@ export class Player
         this.getEntityManager().addEntity(sound);
       } else if (activeWeapon.key === "Shotgun") {
         // Create 3 bullets with spread
-        const spreadAngle = 16; // degrees
+        const spreadAngle = 8; // degrees
         for (let i = -1; i <= 1; i++) {
           const bullet = new Bullet(this.getEntityManager());
           bullet.setPosition({

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -23,6 +23,7 @@ import { DEBUG } from "../../index";
 import { Cooldown } from "./util/cooldown";
 import { Bandage } from "./items/bandage";
 import { Sound, SOUND_TYPES } from "./sound";
+import { Input } from "../input";
 
 export class Player
   extends Entity
@@ -161,6 +162,7 @@ export class Player
       velocity: this.velocity,
       health: this.health,
       isCrafting: this.isCrafting,
+      input: this.input,
     };
   }
 

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -1,5 +1,4 @@
 import { Entities, Entity, RawEntity } from "../entities";
-import { Input } from "../../server";
 import { EntityManager } from "../../managers/entity-manager";
 import { Bullet } from "./bullet";
 import { Tree } from "./tree";
@@ -107,6 +106,10 @@ export class Player
   }
 
   damage(damage: number): void {
+    if (this.isDead()) {
+      return;
+    }
+
     this.health = Math.max(this.health - damage, 0);
 
     const sound = new Sound(this.getEntityManager(), SOUND_TYPES.PLAYER_HURT);

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -256,7 +256,7 @@ export class Player
         this.getEntityManager().addEntity(sound);
       } else if (activeWeapon.key === "Shotgun") {
         // Create 3 bullets with spread
-        const spreadAngle = 2; // degrees
+        const spreadAngle = 16; // degrees
         for (let i = -1; i <= 1; i++) {
           const bullet = new Bullet(this.getEntityManager());
           bullet.setPosition({

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -428,10 +428,6 @@ export class Player
       return;
     }
 
-    if (this.input.inventoryItem !== null) {
-      this.activeItem = this.inventory[this.input.inventoryItem - 1];
-    }
-
     this.handleAttack(deltaTime);
     this.handleMovement(deltaTime);
     this.handleInteract(deltaTime);
@@ -441,6 +437,12 @@ export class Player
 
   setInput(input: Input) {
     this.input = input;
+
+    if (this.input.inventoryItem !== null) {
+      this.activeItem = this.inventory[this.input.inventoryItem - 1] ?? null;
+    } else {
+      this.activeItem = null;
+    }
   }
 
   heal(amount: number): void {

--- a/packages/game-server/src/shared/entities/zombie.ts
+++ b/packages/game-server/src/shared/entities/zombie.ts
@@ -77,10 +77,14 @@ export class Zombie
   }
 
   damage(damage: number) {
+    if (this.isDead()) {
+      return;
+    }
+
     this.health -= damage;
 
     if (this.health <= 0) {
-      this.getEntityManager().markEntityForRemoval(this);
+      this.getEntityManager().markEntityForRemoval(this, 5000);
     }
   }
 
@@ -137,6 +141,10 @@ export class Zombie
   }
 
   update(deltaTime: number) {
+    if (this.isDead()) {
+      return;
+    }
+
     const player = this.getEntityManager().getClosestAlivePlayer(this);
     if (!player) return;
 

--- a/packages/game-server/src/shared/input.ts
+++ b/packages/game-server/src/shared/input.ts
@@ -1,0 +1,12 @@
+import { Direction } from "./direction";
+
+export type Input = {
+  facing: Direction;
+  dx: number;
+  dy: number;
+  interact: boolean;
+  fire: boolean;
+  inventoryItem: number;
+  drop: boolean;
+  consume: boolean;
+};


### PR DESCRIPTION
- Fix issue with .env.example being not present
- Add crafting field to global game state
- Clear inventory on death
- Fix rendered player facing direction
- Don't damage player if dead
- Fix showing player's current active item
- Increase shotgun spread angle
- Render disabled crafting recipe red
- Don't allow crafting disabled recipe
- Fix zombie walking over dead players
- Delay removing zombies