### PR TITLE
Extensions concept, Zombie looting, Bandage recipe

### DIFF
--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -7,7 +7,7 @@ import {
   EntityType,
   GameStateEvent,
   Input,
-  Positionable,
+  PositionableTrait,
 } from "@survive-the-night/game-server";
 import { PlayerClient } from "./entities/player";
 import { ZombieClient } from "./entities/zombie";
@@ -24,6 +24,7 @@ import { WallClient } from "./entities/wall";
 import { Hud } from "./ui/hud";
 import { WeaponClient } from "./entities/weapon";
 import { BandageClient } from "./entities/items/bandage";
+import { ClothClient } from "./entities/items/cloth";
 import { SoundClient } from "./entities/sound";
 
 export class GameClient {
@@ -74,6 +75,11 @@ export class GameClient {
     [Entities.BANDAGE]: (data) => {
       const entity = new BandageClient(data.id, this.assetManager);
       this.initializeEntity(entity, data);
+      return entity;
+    },
+    [Entities.CLOTH]: (data) => {
+      const entity = new ClothClient(data.id, this.assetManager);
+      entity.deserialize(data);
       return entity;
     },
     [Entities.ZOMBIE]: (data) => {
@@ -318,7 +324,12 @@ export class GameClient {
       const existingEntity = this.getEntities().find((e) => e.getId() === entityData.id);
 
       if (existingEntity) {
-        Object.assign(existingEntity, entityData);
+        if ("deserialize" in existingEntity) {
+          existingEntity.deserialize(entityData);
+        } else {
+          Object.assign(existingEntity, entityData);
+        }
+
         continue;
       }
 
@@ -352,7 +363,7 @@ export class GameClient {
       return;
     }
 
-    const playerToFollow = getEntityById(this.gameState, playerId) as Positionable | undefined;
+    const playerToFollow = getEntityById(this.gameState, playerId) as PositionableTrait | undefined;
 
     if (playerToFollow) {
       this.cameraManager.translateTo(playerToFollow.getPosition());

--- a/packages/game-client/src/entities/bullet.ts
+++ b/packages/game-client/src/entities/bullet.ts
@@ -1,10 +1,10 @@
-import { Entities, EntityType, Positionable, Vector2 } from "@survive-the-night/game-server";
+import { Entities, EntityType, PositionableTrait, Vector2 } from "@survive-the-night/game-server";
 import { AssetManager } from "@/managers/asset";
 import { GameState } from "../state";
 import { IClientEntity, Renderable } from "./util";
 import { HITBOX_RADIUS } from "@survive-the-night/game-server/src/shared/entities/bullet";
 
-export class BulletClient implements IClientEntity, Renderable, Positionable {
+export class BulletClient implements IClientEntity, Renderable, PositionableTrait {
   private assetManager: AssetManager;
   private position: Vector2 = { x: 0, y: 0 };
   private type: EntityType;

--- a/packages/game-client/src/entities/items/bandage.ts
+++ b/packages/game-client/src/entities/items/bandage.ts
@@ -3,7 +3,7 @@ import {
   Entities,
   EntityType,
   Player,
-  Positionable,
+  PositionableTrait,
   Vector2,
 } from "@survive-the-night/game-server";
 import { AssetManager } from "@/managers/asset";
@@ -12,7 +12,7 @@ import { IClientEntity, Renderable } from "../util";
 
 const TREE_SIZE = 16;
 
-export class BandageClient implements Renderable, Positionable, IClientEntity {
+export class BandageClient implements Renderable, PositionableTrait, IClientEntity {
   private assetManager: AssetManager;
   private type: EntityType;
   private id: string;
@@ -57,7 +57,7 @@ export class BandageClient implements Renderable, Positionable, IClientEntity {
 
   render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
     const image = this.assetManager.get("Bandage");
-    const myPlayer = getEntityById(gameState, gameState.playerId) as Positionable | undefined;
+    const myPlayer = getEntityById(gameState, gameState.playerId) as PositionableTrait | undefined;
 
     if (
       myPlayer &&

--- a/packages/game-client/src/entities/items/cloth.ts
+++ b/packages/game-client/src/entities/items/cloth.ts
@@ -1,0 +1,41 @@
+import {
+  GenericEntity,
+  Player,
+  Positionable,
+  PositionableTrait,
+  RawEntity,
+  distance,
+} from "@survive-the-night/game-server";
+import { AssetManager } from "@/managers/asset";
+import { GameState, getEntityById } from "../../state";
+import { Renderable } from "../util";
+
+const ENTITY_SIZE = 16;
+
+export class ClothClient extends GenericEntity implements Renderable {
+  private assetManager: AssetManager;
+
+  constructor(data: RawEntity, assetManager: AssetManager) {
+    super(data);
+    this.assetManager = assetManager;
+  }
+
+  render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
+    const image = this.assetManager.get("Cloth");
+    const myPlayer = getEntityById(gameState, gameState.playerId) as PositionableTrait | undefined;
+    const positionable = this.getExt(Positionable);
+    const position = positionable.getPosition();
+
+    if (myPlayer && distance(myPlayer.getPosition(), position) < Player.MAX_INTERACT_RADIUS) {
+      ctx.fillStyle = "white";
+      ctx.font = "6px Arial";
+      const text = "collect (e)";
+      const textWidth = ctx.measureText(text).width;
+      ctx.fillText(text, position.x + ENTITY_SIZE / 2 - textWidth / 2, position.y - 3);
+
+      console.log(textWidth);
+    }
+
+    ctx.drawImage(image, position.x, position.y);
+  }
+}

--- a/packages/game-client/src/entities/items/cloth.ts
+++ b/packages/game-client/src/entities/items/cloth.ts
@@ -32,8 +32,6 @@ export class ClothClient extends GenericEntity implements Renderable {
       const text = "collect (e)";
       const textWidth = ctx.measureText(text).width;
       ctx.fillText(text, position.x + ENTITY_SIZE / 2 - textWidth / 2, position.y - 3);
-
-      console.log(textWidth);
     }
 
     ctx.drawImage(image, position.x, position.y);

--- a/packages/game-client/src/entities/player.ts
+++ b/packages/game-client/src/entities/player.ts
@@ -1,7 +1,7 @@
 import {
   Entities,
   EntityType,
-  Positionable,
+  PositionableTrait,
   roundVector2,
   Vector2,
   InventoryItem,
@@ -18,7 +18,7 @@ import { GameState } from "@/state";
 import { getHitboxWithPadding } from "@survive-the-night/game-server/src/shared/entities/util";
 import { debugDrawHitbox } from "../util/debug";
 
-export class PlayerClient implements IClientEntity, Renderable, Positionable, Damageable {
+export class PlayerClient implements IClientEntity, Renderable, PositionableTrait, Damageable {
   private readonly LERP_FACTOR = 0.1;
   private readonly ARROW_LENGTH = 20;
 

--- a/packages/game-client/src/entities/tree.ts
+++ b/packages/game-client/src/entities/tree.ts
@@ -3,7 +3,7 @@ import {
   Entities,
   EntityType,
   Player,
-  Positionable,
+  PositionableTrait,
   Vector2,
 } from "@survive-the-night/game-server";
 import { AssetManager } from "@/managers/asset";
@@ -12,7 +12,7 @@ import { IClientEntity, Renderable } from "./util";
 
 const TREE_SIZE = 16;
 
-export class TreeClient implements Renderable, Positionable, IClientEntity {
+export class TreeClient implements Renderable, PositionableTrait, IClientEntity {
   private assetManager: AssetManager;
   private type: EntityType;
   private id: string;
@@ -57,7 +57,7 @@ export class TreeClient implements Renderable, Positionable, IClientEntity {
 
   render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
     const image = this.assetManager.get("Tree");
-    const myPlayer = getEntityById(gameState, gameState.playerId) as Positionable | undefined;
+    const myPlayer = getEntityById(gameState, gameState.playerId) as PositionableTrait | undefined;
 
     if (
       myPlayer &&

--- a/packages/game-client/src/entities/util.ts
+++ b/packages/game-client/src/entities/util.ts
@@ -1,4 +1,4 @@
-import { Positionable, Vector2 } from "@survive-the-night/game-server";
+import { Vector2 } from "@survive-the-night/game-server";
 import { GameState } from "../state";
 
 export interface Animation {

--- a/packages/game-client/src/entities/wall.ts
+++ b/packages/game-client/src/entities/wall.ts
@@ -5,7 +5,7 @@ import {
   EntityType,
   Hitbox,
   Player,
-  Positionable,
+  PositionableTrait,
   Vector2,
 } from "@survive-the-night/game-server";
 import { AssetManager } from "@/managers/asset";
@@ -15,7 +15,7 @@ import { WALL_MAX_HEALTH } from "@survive-the-night/game-server/src/shared/entit
 
 const WALL_SIZE = 16;
 
-export class WallClient implements Renderable, Positionable, IClientEntity, Damageable {
+export class WallClient implements Renderable, PositionableTrait, IClientEntity, Damageable {
   private assetManager: AssetManager;
   private type: EntityType;
   private id: string;
@@ -88,7 +88,7 @@ export class WallClient implements Renderable, Positionable, IClientEntity, Dama
     const image = this.assetManager.get("Wall");
     ctx.drawImage(image, this.getPosition().x, this.getPosition().y);
 
-    const myPlayer = getEntityById(gameState, gameState.playerId) as Positionable | undefined;
+    const myPlayer = getEntityById(gameState, gameState.playerId) as PositionableTrait | undefined;
     if (
       myPlayer &&
       distance(myPlayer.getPosition(), this.getPosition()) < Player.MAX_INTERACT_RADIUS

--- a/packages/game-client/src/entities/weapon.ts
+++ b/packages/game-client/src/entities/weapon.ts
@@ -3,7 +3,7 @@ import {
   Entities,
   EntityType,
   Player,
-  Positionable,
+  PositionableTrait,
   Vector2,
   WeaponType,
 } from "@survive-the-night/game-server";
@@ -13,7 +13,7 @@ import { Animatable, animate, Animation, IClientEntity, Renderable } from "./uti
 
 const WEAPON_SIZE = 16;
 
-export class WeaponClient implements Renderable, Animatable, Positionable, IClientEntity {
+export class WeaponClient implements Renderable, Animatable, PositionableTrait, IClientEntity {
   private assetManager: AssetManager;
   private type: EntityType;
   private weaponType: WeaponType;
@@ -80,7 +80,7 @@ export class WeaponClient implements Renderable, Animatable, Positionable, IClie
 
   public render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
     const image = this.assetManager.get(this.weaponType);
-    const myPlayer = getEntityById(gameState, gameState.playerId) as Positionable | undefined;
+    const myPlayer = getEntityById(gameState, gameState.playerId) as PositionableTrait | undefined;
 
     if (
       myPlayer &&

--- a/packages/game-client/src/managers/asset.ts
+++ b/packages/game-client/src/managers/asset.ts
@@ -68,6 +68,7 @@ const zombieRightFrameOrigins = getFrameOrigins({ startX: 496, startY: 95, total
 
 // sheet gaps: 1px horizontally, 3px vertically
 export const assetsMap = {
+  Cloth: assetMap({ x: 51, y: 228 }),
   Knife: assetMap({ x: 17, y: 171 }),
   KnifeFacingDown: assetMap({ x: 51, y: 171 }),
   KnifeFacingLeft: assetMap({ x: 17, y: 171, flipX: true }),
@@ -239,6 +240,8 @@ export function getItemAssetKey(item: InventoryItem): Asset {
     return "Wall";
   } else if (item.key === "Bandage") {
     return "Bandage";
+  } else if (item.key === "Cloth") {
+    return "Cloth";
   }
 
   throw new Error(`Unknown item type '${item.key}'`);

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -1,4 +1,4 @@
-import { Damageable, Positionable } from "@survive-the-night/game-server";
+import { Damageable } from "@survive-the-night/game-server";
 import { GameState, getEntityById } from "../state";
 
 const HUD_SETTINGS = {

--- a/packages/game-server/src/index.ts
+++ b/packages/game-server/src/index.ts
@@ -8,5 +8,6 @@ export * from "./shared/recipes";
 export * from "./shared/traits";
 export * from "./shared/direction";
 export * from "./shared/input";
+export * from "./shared/extensions";
 
 export const DEBUG = false;

--- a/packages/game-server/src/managers/spatial-grid.ts
+++ b/packages/game-server/src/managers/spatial-grid.ts
@@ -26,8 +26,9 @@ export class SpatialGrid {
     }
   }
 
-  addEntity(entity: Entity & Positionable) {
-    const pos = entity.getPosition();
+  addEntity(entity: Entity) {
+    const pos =
+      "getPosition" in entity ? entity.getPosition() : entity.getExt(Positionable).getPosition();
     const [cellX, cellY] = this.getCellCoords(pos);
 
     if (this.isValidCell(cellX, cellY)) {

--- a/packages/game-server/src/shared/entities/boundary.ts
+++ b/packages/game-server/src/shared/entities/boundary.ts
@@ -1,9 +1,9 @@
 import { EntityManager } from "../../managers/entity-manager";
 import { Entity, Entities, RawEntity } from "../entities";
-import { Collidable, Hitbox, Positionable, ServerOnly } from "../traits";
+import { Collidable, Hitbox, PositionableTrait, ServerOnly } from "../traits";
 import { Vector2 } from "../physics";
 
-export class Boundary extends Entity implements Collidable, Positionable, ServerOnly {
+export class Boundary extends Entity implements Collidable, PositionableTrait, ServerOnly {
   private position: Vector2 = {
     x: 0,
     y: 0,

--- a/packages/game-server/src/shared/entities/bullet.ts
+++ b/packages/game-server/src/shared/entities/bullet.ts
@@ -11,7 +11,7 @@ import {
   Hitbox,
   IntersectionMethodIdentifiers,
   Movable,
-  Positionable,
+  PositionableTrait,
   Updatable,
 } from "../traits";
 
@@ -19,7 +19,7 @@ const MAX_TRAVEL_DISTANCE = 400;
 
 export const HITBOX_RADIUS = 1;
 
-export class Bullet extends Entity implements Positionable, Movable, Updatable, Collidable {
+export class Bullet extends Entity implements PositionableTrait, Movable, Updatable, Collidable {
   private traveledDistance: number = 0;
   private position: Vector2 = { x: 0, y: 0 };
   private velocity: Vector2 = { x: 0, y: 0 };

--- a/packages/game-server/src/shared/entities/items/bandage.ts
+++ b/packages/game-server/src/shared/entities/items/bandage.ts
@@ -1,10 +1,10 @@
 import { EntityManager } from "../../../managers/entity-manager";
 import { Entity, Entities, RawEntity } from "../../entities";
-import { Interactable, Hitbox, Positionable, Consumable } from "../../traits";
+import { Interactable, PositionableTrait, Consumable } from "../../traits";
 import { Vector2 } from "../../physics";
 import { Player } from "../player";
 
-export class Bandage extends Entity implements Positionable, Interactable, Consumable {
+export class Bandage extends Entity implements PositionableTrait, Interactable, Consumable {
   private position: Vector2 = {
     x: 0,
     y: 0,

--- a/packages/game-server/src/shared/entities/items/cloth.ts
+++ b/packages/game-server/src/shared/entities/items/cloth.ts
@@ -18,6 +18,10 @@ export class Cloth extends Entity {
     this.addEventListener(Events.INTERACT, (evt: CustomEventInit<Player>) => {
       const player = evt.detail;
 
+      if (player?.isInventoryFull()) {
+        return;
+      }
+
       player?.getInventory().push({ key: "Cloth" });
       this.getEntityManager().markEntityForRemoval(this);
     });

--- a/packages/game-server/src/shared/entities/items/cloth.ts
+++ b/packages/game-server/src/shared/entities/items/cloth.ts
@@ -1,0 +1,25 @@
+import { EntityManager } from "../../../managers/entity-manager";
+import { Entity, Entities } from "../../entities";
+import { Interactive, Positionable } from "../../extensions";
+import { Events } from "../../events";
+import { Player } from "../player";
+
+export class Cloth extends Entity {
+  constructor(entityManager: EntityManager) {
+    super(entityManager, Entities.CLOTH);
+
+    this.extensions = [
+      new Positionable(this),
+      new Interactive(this).init({
+        eventName: Events.INTERACT,
+      }),
+    ];
+
+    this.addEventListener(Events.INTERACT, (evt: CustomEventInit<Player>) => {
+      const player = evt.detail;
+
+      player?.getInventory().push({ key: "Cloth" });
+      this.getEntityManager().markEntityForRemoval(this);
+    });
+  }
+}

--- a/packages/game-server/src/shared/entities/player.ts
+++ b/packages/game-server/src/shared/entities/player.ts
@@ -312,7 +312,6 @@ export class Player
         const p2 = "getPosition" in b ? b.getPosition() : b.getExt(Positionable).getPosition();
         return distance(this.position, p1) - distance(this.position, p2);
       });
-      console.log(entities, byProximity);
 
       if (byProximity.length > 0) {
         const entity = byProximity[0];

--- a/packages/game-server/src/shared/entities/sound.ts
+++ b/packages/game-server/src/shared/entities/sound.ts
@@ -2,7 +2,7 @@ import { Entities, RawEntity } from "../entities";
 
 import { EntityManager } from "@/managers/entity-manager";
 import { Entity } from "../entities";
-import { Positionable } from "../traits";
+import { PositionableTrait } from "../traits";
 import { Vector2 } from "../physics";
 
 export const SOUND_TYPES = {
@@ -13,7 +13,7 @@ export const SOUND_TYPES = {
 
 export type SoundType = (typeof SOUND_TYPES)[keyof typeof SOUND_TYPES];
 
-export class Sound extends Entity implements Positionable {
+export class Sound extends Entity implements PositionableTrait {
   private position: Vector2 = { x: 0, y: 0 };
   private soundType: SoundType;
   public constructor(entityManager: EntityManager, soundType: SoundType) {

--- a/packages/game-server/src/shared/entities/tree.ts
+++ b/packages/game-server/src/shared/entities/tree.ts
@@ -1,10 +1,10 @@
 import { EntityManager } from "../../managers/entity-manager";
 import { Entities, Entity, RawEntity } from "../entities";
 import { Vector2 } from "../physics";
-import { Interactable, Positionable } from "../traits";
+import { Interactable, PositionableTrait } from "../traits";
 import { Player } from "./player";
 
-export class Tree extends Entity implements Interactable, Positionable {
+export class Tree extends Entity implements Interactable, PositionableTrait {
   private position: Vector2 = { x: 0, y: 0 };
 
   constructor(entityManager: EntityManager) {

--- a/packages/game-server/src/shared/entities/wall.ts
+++ b/packages/game-server/src/shared/entities/wall.ts
@@ -1,13 +1,16 @@
 import { EntityManager } from "../../managers/entity-manager";
 import { Entity, Entities, RawEntity } from "../entities";
-import { Collidable, Damageable, Interactable, Hitbox, Positionable } from "../traits";
+import { Collidable, Damageable, Interactable, Hitbox, PositionableTrait } from "../traits";
 import { Vector2 } from "../physics";
 import { Player } from "./player";
 import { TILE_SIZE } from "../../managers/map-manager";
 
 export const WALL_MAX_HEALTH = 5;
 
-export class Wall extends Entity implements Collidable, Positionable, Interactable, Damageable {
+export class Wall
+  extends Entity
+  implements Collidable, PositionableTrait, Interactable, Damageable
+{
   private position: Vector2 = {
     x: 0,
     y: 0,

--- a/packages/game-server/src/shared/entities/weapon.ts
+++ b/packages/game-server/src/shared/entities/weapon.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from "../../managers/entity-manager";
 import { Entity, Entities, RawEntity } from "../entities";
 import { Vector2 } from "../physics";
-import { Interactable, Positionable } from "../traits";
+import { Interactable, PositionableTrait } from "../traits";
 import { Player } from "./player";
 
 export const WEAPON_TYPES = {
@@ -11,7 +11,7 @@ export const WEAPON_TYPES = {
 } as const;
 export type WeaponType = (typeof WEAPON_TYPES)[keyof typeof WEAPON_TYPES];
 
-export class Weapon extends Entity implements Interactable, Positionable {
+export class Weapon extends Entity implements Interactable, PositionableTrait {
   private weaponType: WeaponType;
   private position: Vector2 = { x: 0, y: 0 };
 

--- a/packages/game-server/src/shared/events.ts
+++ b/packages/game-server/src/shared/events.ts
@@ -9,6 +9,8 @@ export const Events = {
   START_CRAFTING: "startCrafting",
   STOP_CRAFTING: "stopCrafting",
   PLAYER_DEATH: "playerDeath",
+  SCATTER_LOOT: "scatterLoot",
+  INTERACT: "interact",
 } as const;
 
 export type Event = (typeof Events)[keyof typeof Events];

--- a/packages/game-server/src/shared/extensions/index.ts
+++ b/packages/game-server/src/shared/extensions/index.ts
@@ -1,0 +1,10 @@
+import Interactive from "./interactive";
+import Positionable from "./positionable";
+
+export const extensionsMap = {
+  [Interactive.Name]: Interactive,
+  [Positionable.Name]: Positionable,
+} as const;
+
+export { Interactive, Positionable };
+export * from "./types";

--- a/packages/game-server/src/shared/extensions/interactive.ts
+++ b/packages/game-server/src/shared/extensions/interactive.ts
@@ -24,10 +24,6 @@ export default class Interactive implements Extension {
   }
 
   public interact(player: Player): void {
-    if (player.isInventoryFull()) {
-      return;
-    }
-
     if (this.eventName !== null) {
       this.self.dispatchEvent(
         new CustomEvent(this.eventName, {

--- a/packages/game-server/src/shared/extensions/interactive.ts
+++ b/packages/game-server/src/shared/extensions/interactive.ts
@@ -1,0 +1,51 @@
+import { GenericEntity } from "../entities";
+import { Player } from "../entities/player";
+import { Extension, ExtensionNames, ExtensionSerialized } from "./types";
+
+interface InteractiveOptions {
+  eventName?: string;
+}
+
+export default class Interactive implements Extension {
+  public static readonly Name = ExtensionNames.interactive;
+
+  private self: GenericEntity;
+  private eventName: string | null = null;
+
+  public constructor(self: GenericEntity) {
+    this.self = self;
+  }
+
+  public init(options: InteractiveOptions): this {
+    if (options.eventName !== undefined) {
+      this.eventName = options.eventName;
+    }
+    return this;
+  }
+
+  public interact(player: Player): void {
+    if (player.isInventoryFull()) {
+      return;
+    }
+
+    if (this.eventName !== null) {
+      this.self.dispatchEvent(
+        new CustomEvent(this.eventName, {
+          detail: player,
+        })
+      );
+    }
+  }
+
+  public deserialize(data: ExtensionSerialized): this {
+    this.eventName = data.eventName;
+    return this;
+  }
+
+  public serialize(): ExtensionSerialized {
+    return {
+      name: Interactive.Name,
+      eventName: this.eventName,
+    };
+  }
+}

--- a/packages/game-server/src/shared/extensions/positionable.ts
+++ b/packages/game-server/src/shared/extensions/positionable.ts
@@ -1,0 +1,38 @@
+import { GenericEntity } from "../entities";
+import { Extension, ExtensionNames, ExtensionSerialized } from "./types";
+import { Vector2 } from "../physics";
+
+export default class Positionable implements Extension {
+  public static readonly Name = ExtensionNames.positionable;
+
+  private self: GenericEntity;
+  private x = 0;
+  private y = 0;
+
+  public constructor(self: GenericEntity) {
+    this.self = self;
+  }
+
+  public getPosition(): Vector2 {
+    return { x: this.x, y: this.y };
+  }
+
+  public setPosition(position: Vector2): void {
+    this.x = position.x;
+    this.y = position.y;
+  }
+
+  public deserialize(data: ExtensionSerialized): this {
+    this.x = data.x;
+    this.y = data.y;
+    return this;
+  }
+
+  public serialize(): ExtensionSerialized {
+    return {
+      name: Positionable.Name,
+      x: this.x,
+      y: this.y,
+    };
+  }
+}

--- a/packages/game-server/src/shared/extensions/types.ts
+++ b/packages/game-server/src/shared/extensions/types.ts
@@ -1,0 +1,16 @@
+export const ExtensionNames = {
+  interactive: "interactive",
+  positionable: "positionable",
+} as const;
+
+export interface Extension {
+  deserialize: (data: ExtensionSerialized) => this;
+  serialize: () => ExtensionSerialized;
+}
+
+export type ExtensionCtor<T = any> = { new (...args: any[]): T };
+
+export interface ExtensionSerialized {
+  name: keyof typeof ExtensionNames;
+  [key: string]: any;
+}

--- a/packages/game-server/src/shared/inventory.ts
+++ b/packages/game-server/src/shared/inventory.ts
@@ -1,4 +1,4 @@
-export type ItemType = "Knife" | "Shotgun" | "Pistol" | "Wood" | "Wall" | "Bandage";
+export type ItemType = "Knife" | "Shotgun" | "Pistol" | "Wood" | "Wall" | "Bandage" | "Cloth";
 
 export interface InventoryItem {
   key: ItemType;

--- a/packages/game-server/src/shared/recipes.ts
+++ b/packages/game-server/src/shared/recipes.ts
@@ -1,11 +1,13 @@
 import { InventoryItem, ItemType } from "./inventory";
+import { BandageRecipe } from "./recipes/bandage-recipe";
 import { WallRecipe } from "./recipes/wall-recipe";
 
 export enum RecipeType {
+  Bandage = "bandage",
   Wall = "wall",
 }
 
-export const recipes: Recipe[] = [new WallRecipe()];
+export const recipes: Recipe[] = [new BandageRecipe(), new WallRecipe()];
 
 export interface RecipeComponent {
   type: ItemType;

--- a/packages/game-server/src/shared/recipes/bandage-recipe.ts
+++ b/packages/game-server/src/shared/recipes/bandage-recipe.ts
@@ -1,0 +1,36 @@
+import { InventoryItem } from "../inventory";
+import { craftRecipe, Recipe, recipeCanBeCrafted, RecipeComponent, RecipeType } from "../recipes";
+
+export class BandageRecipe implements Recipe {
+  public getType(): RecipeType {
+    return RecipeType.Bandage;
+  }
+
+  public canBeCrafted(inventory: InventoryItem[]): boolean {
+    return recipeCanBeCrafted(this, inventory);
+  }
+
+  public components(): RecipeComponent[] {
+    return [
+      {
+        type: "Cloth",
+      },
+      {
+        type: "Cloth",
+      },
+      {
+        type: "Cloth",
+      },
+    ];
+  }
+
+  public craft(inventory: InventoryItem[]): InventoryItem[] {
+    return craftRecipe(this, inventory);
+  }
+
+  public resultingComponent(): RecipeComponent {
+    return {
+      type: "Bandage",
+    };
+  }
+}

--- a/packages/game-server/src/shared/traits.ts
+++ b/packages/game-server/src/shared/traits.ts
@@ -7,7 +7,7 @@ export interface Interactable {
 
 export const InteractableKey = "interact";
 
-export interface Positionable {
+export interface PositionableTrait {
   getPosition: () => Vector2;
   setPosition: (position: Vector2) => void;
   getCenterPosition: () => Vector2;


### PR DESCRIPTION
I named it extensions to avoid collision with Traits we already have.
Extensions are well... extend base functionality of any entity. Extensions are independent.
Entity (used on Server) is not inheriting from GenericEntity. This will allow using GenericEntity on both client and server.
We may want to create ClientEntity for client and rename Entity to ServerEntity for server.
I rename Positionable to PositionableTrait to avoid name collision. I feel like we will be moving towards extensions setup, as they work super nice.
Generic entity has serialize/deserialize methods - these methods allow to pass updates from server to client (later we can remove Object.assign tweak).
For examples on how to use new extensions look at Cloth entity on both client and server.
You can find extensions examples in server/extensions folder.