### PR TITLE
Spike Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+scratch.txt

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,6 @@ Feel free to pick any item listed out here to work on.
 
 ### Gameplay
 
-- [ ] when a player is killed, notify all players in the game a player has died
 - [ ] during daytime, zombies should just wander around randomly, but will attack players if they get close
 - [ ] if ALL players die, the game ends
 - [ ] show a message that the players lost, and show a leaderboard with how many kills each player got
@@ -28,6 +27,17 @@ Feel free to pick any item listed out here to work on.
 - [ ] items should have a weight associated with them
 - [ ] your inventory weight should slow you down
 - [ ] a player should be able to leave the game
+
+### Stuff
+
+- [ ] melee attack
+- [ ] all players spawn with a random melee weapon
+- [ ] lighting system (night cycle is pitch black, small fov near players)
+- [ ] craft torch (wood, cloth, flint)
+- [ ] place torch (acts as lighting)
+- [ ] more base structures (spike floor trap, hurts zombies if they walk over it)
+- [ ] zombies who vomit (range attack)
+- [ ] ammo system
 
 ### HUD
 
@@ -96,6 +106,7 @@ Feel free to pick any item listed out here to work on.
 ## Change Log:
 
 - [x] 12/15/2024: add a way to toggle the instructions on and off
+- [x] 12/18/2024: when a player is killed, notify all players in the game a player has died
 - [x] a user can drop items from their inventory
 - [x] a user shall be able to harvest trees
 - [x] create an entry point function for the client code which creates a canvas, connects to a server, and starts the game loop

--- a/packages/game-client/src/entities/buildings/spikes.ts
+++ b/packages/game-client/src/entities/buildings/spikes.ts
@@ -1,9 +1,9 @@
 import {
-  DEBUG,
   GenericEntity,
   Positionable,
   RawEntity,
   Triggerable,
+  TriggerCooldownAttacker,
 } from "@survive-the-night/game-server";
 import { AssetManager } from "../../managers/asset";
 import { GameState } from "../../state";
@@ -27,7 +27,15 @@ export class SpikesClient extends GenericEntity implements Renderable {
     const image = this.assetManager.get("Spikes");
     const positionable = this.getExt(Positionable);
     const centerPosition = positionable.getCenterPosition();
-    ctx.drawImage(image, centerPosition.x, centerPosition.y);
+    const extension = this.getExt(TriggerCooldownAttacker);
+
+    if (extension.isReady) {
+      ctx.drawImage(image, centerPosition.x, centerPosition.y);
+    } else {
+      ctx.globalAlpha = 0.5;
+      ctx.drawImage(image, centerPosition.x, centerPosition.y);
+      ctx.globalAlpha = 1;
+    }
 
     debugDrawHitbox(ctx, this.getExt(Triggerable).getTriggerBox(), "red");
   }

--- a/packages/game-client/src/entities/entity-factory.ts
+++ b/packages/game-client/src/entities/entity-factory.ts
@@ -1,0 +1,85 @@
+import { IClientEntity } from "./util";
+import { Entities, EntityType } from "@survive-the-night/game-server";
+import { PlayerClient } from "./player";
+import { TreeClient } from "./tree";
+import { BulletClient } from "./bullet";
+import { WallClient } from "./wall";
+import { WeaponClient } from "./weapon";
+import { BandageClient } from "./items/bandage";
+import { ClothClient } from "./items/cloth";
+import { ZombieClient } from "./zombie";
+import { SoundClient } from "./sound";
+import { SpikesClient } from "./buildings/spikes";
+import { EntityDto } from "../managers/socket";
+import { AssetManager } from "@/managers/asset";
+
+export class EntityFactory {
+  private assetManager: AssetManager;
+
+  constructor(assetManager: AssetManager) {
+    this.assetManager = assetManager;
+  }
+
+  public createEntity(entityType: EntityType, entityData: EntityDto) {
+    // TODO: find a way to reduce the need to update this every time we add a new entity
+    // it's easy to forget.
+    const entityMap = {
+      [Entities.PLAYER]: (data: EntityDto) => {
+        const entity = new PlayerClient(data.id, this.assetManager);
+        this.initializeEntity(entity, data);
+        return entity;
+      },
+      [Entities.TREE]: (data: EntityDto) => {
+        const entity = new TreeClient(data, this.assetManager);
+        entity.deserialize(data);
+        return entity;
+      },
+      [Entities.BULLET]: (data: EntityDto) => {
+        const entity = new BulletClient(data.id, this.assetManager);
+        this.initializeEntity(entity, data);
+        return entity;
+      },
+      [Entities.WALL]: (data: EntityDto) => {
+        const entity = new WallClient(data.id, this.assetManager);
+        entity.deserialize(data);
+        return entity;
+      },
+      [Entities.WEAPON]: (data: EntityDto) => {
+        const entity = new WeaponClient(data, this.assetManager, data.weaponType);
+        entity.deserialize(data);
+        return entity;
+      },
+      [Entities.BANDAGE]: (data: EntityDto) => {
+        const entity = new BandageClient(data, this.assetManager);
+        entity.deserialize(data);
+        return entity;
+      },
+      [Entities.CLOTH]: (data: EntityDto) => {
+        const entity = new ClothClient(data, this.assetManager);
+        entity.deserialize(data);
+        return entity;
+      },
+      [Entities.ZOMBIE]: (data: EntityDto) => {
+        const entity = new ZombieClient(data.id, this.assetManager);
+        this.initializeEntity(entity, data);
+        return entity;
+      },
+      [Entities.SOUND]: (data: EntityDto) => {
+        const entity = new SoundClient(data.id, data.soundType);
+        this.initializeEntity(entity, data);
+        return entity;
+      },
+      [Entities.SPIKES]: (data: EntityDto) => {
+        const entity = new SpikesClient(data, this.assetManager);
+        entity.deserialize(data);
+        return entity;
+      },
+    };
+
+    return entityMap[entityType](entityData) as IClientEntity;
+  }
+
+  private initializeEntity(entity: IClientEntity, data: EntityDto): void {
+    Object.assign(entity, data);
+  }
+}

--- a/packages/game-client/src/entities/util.ts
+++ b/packages/game-client/src/entities/util.ts
@@ -6,7 +6,9 @@ export interface Renderable {
   getZIndex: () => number;
 }
 
-export interface IClientEntity {}
+export interface IClientEntity {
+  getId: () => string;
+}
 
 export function getFrameIndex(
   startedAt: number,

--- a/packages/game-server/src/index.ts
+++ b/packages/game-server/src/index.ts
@@ -10,4 +10,4 @@ export * from "./shared/direction";
 export * from "./shared/input";
 export * from "./shared/extensions";
 
-export const DEBUG = true;
+export const DEBUG = false;

--- a/packages/game-server/src/managers/socket-manager.ts
+++ b/packages/game-server/src/managers/socket-manager.ts
@@ -79,7 +79,7 @@ export class SocketManager {
     socket.emit(Events.MAP, map);
     socket.emit(Events.YOUR_ID, player.getId());
 
-    socket.on("playerInput", (input: Input) => this.onPlayerInput(socket, input));
+    socket.on(Events.PLAYER_INPUT, (input: Input) => this.onPlayerInput(socket, input));
     socket.on(Events.CRAFT_REQUEST, (recipe: RecipeType) => this.onCraftRequest(socket, recipe));
     socket.on(Events.START_CRAFTING, (recipe: RecipeType) => this.setPlayerCrafting(socket, true));
     socket.on(Events.STOP_CRAFTING, (recipe: RecipeType) => this.setPlayerCrafting(socket, false));

--- a/packages/game-server/src/shared/entities/buildings/spikes.ts
+++ b/packages/game-server/src/shared/entities/buildings/spikes.ts
@@ -1,18 +1,13 @@
-import { Rectangle } from "../../geom/rectangle";
-import { distance } from "../../physics";
 import { EntityManager } from "../../../managers/entity-manager";
-import { Entity, Entities, RawEntity } from "../../entities";
-import { Positionable } from "../../extensions";
+import { Entity, Entities } from "../../entities";
+import { Positionable, TriggerCooldownAttacker } from "../../extensions";
 import Triggerable from "../../extensions/trigger";
-import Updatable from "../../extensions/updatable";
-import { Zombie } from "../zombie";
 
 /**
  * A spike trap which only hurts zombies who step on it.  After it fires, it'll be removed from the map.
  */
 export class Spikes extends Entity {
   private static readonly DAMAGE = 1;
-  private static readonly RADIUS = 5;
   private static readonly SIZE = 16;
 
   constructor(entityManager: EntityManager) {
@@ -21,28 +16,10 @@ export class Spikes extends Entity {
     this.extensions = [
       new Positionable(this),
       new Triggerable(this, Spikes.SIZE, Spikes.SIZE),
-      new Updatable(this, (deltaTime: number) => {
-        const entityManager = this.getEntityManager();
-        const zombies = entityManager.getNearbyEntities(
-          this.getExt(Positionable).getPosition(),
-          100,
-          [Entities.ZOMBIE]
-        ) as Zombie[];
-
-        const triggerBox = this.getExt(Triggerable).getTriggerBox();
-        const triggerCenter = triggerBox.getCenter();
-
-        for (const zombie of zombies) {
-          const zombieHitbox = new Rectangle(zombie.getHitbox().x, zombie.getHitbox().y, 16, 16);
-          const zombieCenter = zombieHitbox.getCenter();
-
-          const centerDistance = distance(triggerCenter, zombieCenter);
-
-          if (centerDistance < Spikes.RADIUS) {
-            zombie.damage(Spikes.DAMAGE);
-            this.getEntityManager().markEntityForRemoval(this);
-          }
-        }
+      new TriggerCooldownAttacker(this, entityManager, {
+        damage: Spikes.DAMAGE,
+        victimType: Entities.ZOMBIE,
+        cooldown: 1,
       }),
     ];
   }

--- a/packages/game-server/src/shared/entities/util/cooldown.ts
+++ b/packages/game-server/src/shared/entities/util/cooldown.ts
@@ -2,9 +2,17 @@ export class Cooldown {
   private timeRemaining: number = 0;
   private duration: number;
 
-  constructor(duration: number) {
+  constructor(duration: number, startReady: boolean) {
     this.duration = duration;
-    this.reset();
+    if (startReady) {
+      this.setAsReady();
+    } else {
+      this.reset();
+    }
+  }
+
+  setAsReady() {
+    this.timeRemaining = 0;
   }
 
   update(deltaTime: number): void {

--- a/packages/game-server/src/shared/extensions/index.ts
+++ b/packages/game-server/src/shared/extensions/index.ts
@@ -4,6 +4,7 @@ import Destructible from "./destructible";
 import Interactive from "./interactive";
 import Positionable from "./positionable";
 import Triggerable from "./trigger";
+import TriggerCooldownAttacker from "./trigger-cooldown-attacker";
 import Updatable from "./updatable";
 
 export const extensionsMap = {
@@ -14,7 +15,17 @@ export const extensionsMap = {
   [Positionable.Name]: Positionable,
   [Triggerable.Name]: Triggerable,
   [Updatable.Name]: Updatable,
+  [TriggerCooldownAttacker.Name]: TriggerCooldownAttacker,
 } as const;
 
-export { Collidable, Consumable, Destructible, Interactive, Positionable, Triggerable, Updatable };
+export {
+  Collidable,
+  Consumable,
+  Destructible,
+  Interactive,
+  Positionable,
+  Triggerable,
+  Updatable,
+  TriggerCooldownAttacker,
+};
 export * from "./types";

--- a/packages/game-server/src/shared/extensions/trigger-cooldown-attacker.ts
+++ b/packages/game-server/src/shared/extensions/trigger-cooldown-attacker.ts
@@ -1,0 +1,88 @@
+import { Triggerable } from ".";
+import { distance } from "../physics";
+import { Positionable } from "./index";
+import { EntityType, GenericEntity } from "../entities";
+import { Extension, ExtensionNames, ExtensionSerialized } from "./types";
+import { Zombie } from "../entities/zombie";
+import { Rectangle } from "../geom/rectangle";
+import { Cooldown } from "../entities/util/cooldown";
+import { EntityManager } from "@/managers/entity-manager";
+
+/**
+ * This extension will cause the entity to fire an attack when the cooldown is ready.
+ * You can pass in the type of victim you should attack.
+ */
+export default class TriggerCooldownAttacker implements Extension {
+  public static readonly Name = ExtensionNames.triggerCooldownAttacker;
+  private static readonly RADIUS = 16;
+
+  private self: GenericEntity;
+  private entityManager: EntityManager;
+  private attackCooldown: Cooldown;
+  private options: {
+    damage: number;
+    victimType: EntityType;
+    cooldown: number;
+  };
+
+  // SERIALIZED PROPERTIES
+  public isReady: boolean; // used to change spike view
+
+  public constructor(
+    self: GenericEntity,
+    entityManager: EntityManager,
+    options: {
+      damage: number;
+      victimType: EntityType;
+      cooldown: number;
+    }
+  ) {
+    this.self = self;
+    this.entityManager = entityManager;
+    this.attackCooldown = new Cooldown(options.cooldown, true);
+    this.isReady = true;
+    this.options = options;
+  }
+
+  public update(deltaTime: number) {
+    this.attackCooldown.update(deltaTime);
+
+    this.isReady = this.attackCooldown.isReady();
+
+    const entities = this.entityManager.getNearbyEntities(
+      this.self.getExt(Positionable).getPosition(),
+      100,
+      [this.options.victimType]
+    ) as Zombie[];
+
+    const triggerBox = this.self.getExt(Triggerable).getTriggerBox();
+    const triggerCenter = triggerBox.getCenter();
+
+    for (const entity of entities) {
+      const entityHitbox = new Rectangle(entity.getHitbox().x, entity.getHitbox().y, 16, 16);
+      const entityCenter = entityHitbox.getCenter();
+
+      const centerDistance = distance(triggerCenter, entityCenter);
+
+      if (centerDistance < TriggerCooldownAttacker.RADIUS) {
+        if (this.attackCooldown.isReady()) {
+          entity.damage(this.options.damage);
+          this.attackCooldown.reset();
+          break;
+        }
+      }
+    }
+  }
+
+  public deserialize(data: ExtensionSerialized): this {
+    this.isReady = data.isReady;
+    return this;
+  }
+
+  public serialize(): ExtensionSerialized {
+    return {
+      name: TriggerCooldownAttacker.Name,
+      isReady: this.isReady,
+    };
+  }
+}

--- a/packages/game-server/src/shared/extensions/types.ts
+++ b/packages/game-server/src/shared/extensions/types.ts
@@ -6,11 +6,13 @@ export const ExtensionNames = {
   positionable: "positionable",
   trigger: "trigger",
   updatable: "updatable",
+  triggerCooldownAttacker: "triggerCooldownAttacker",
 } as const;
 
 export interface Extension {
   deserialize: (data: ExtensionSerialized) => this;
   serialize: () => ExtensionSerialized;
+  update?: (deltaTime: number) => void;
 }
 
 export type ExtensionCtor<T = any> = { new (...args: any[]): T };

--- a/packages/game-server/src/shared/extensions/updatable.ts
+++ b/packages/game-server/src/shared/extensions/updatable.ts
@@ -6,6 +6,7 @@ export default class Updatable implements Extension {
 
   private self: GenericEntity;
   private updateFunction: (deltaTime: number) => void;
+
   /**
    * will create a trigger box around an entity which should be used for various purposes.
    */


### PR DESCRIPTION
I wanted to create a generic extension that could be used for a zone which deals damage to an enemy type when it's walked over.  This extension has a cooldown and a damage and will serialize an isReady boolean when the trap is ready to attack.  I don't know if anything else in the game could use this extension, but over engineering anyway because that's was engineers do.

- refactoring the spike to use a cooldown extension
- calling all extensions update method if it exists
- making spike transparent when cooling down