### PR TITLE
Added instructions on HUD to drop item

### DIFF
--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -219,6 +219,7 @@ export class Hud {
       "Consume [F]\n" +
       "Harvest [E]\n" +
       "Craft [Q]\n" +
+      "Drop Item [Q]\n" +
       "Toggle Instructions [I]";
 
     const craftingText = "Down [S]\nUp [W]\nCraft [SPACE]";


### PR DESCRIPTION
Surviving beyond the first night is ok, but second or third night gets really tricky since picking up items is a nightmare.

Code is already there, but it's not on the UI. This way people can actually continue to pickup stuff on night 2 or 3 onwards.