### PR TITLE
preserve inventory positions when crafting

### DIFF
--- a/packages/game-shared/src/util/recipes.ts
+++ b/packages/game-shared/src/util/recipes.ts
@@ -83,6 +83,8 @@ export function craftRecipe(
       continue;
     }
 
+    // Preserve inventory positions using empty slots
+    newInventory.push(null as any);
     found.push(componentIdx);
   }
 


### PR DESCRIPTION
Fixes two issues:

- ~~Opening crafting table after dropping an item crashes the game~~
- Inventory positions change after crafting

A more complete solution to avoid similar errors would involve either:

1. Adding `null` to the type signature where `InventoryItem` is used, and removing `as any` type assertions;
2. Adding a new `empty` or `fist` item type as empty slot placeholder to eliminate special case.