### PR TITLE
Hold pickup

### DIFF
--- a/packages/game-client/src/entities/client-entity.ts
+++ b/packages/game-client/src/entities/client-entity.ts
@@ -5,7 +5,7 @@ import { getPlayer } from "@/util/get-player";
 import { renderInteractionText } from "@/util/interaction-text";
 import { ClientEntityBase } from "@/extensions/client-entity";
 import { ImageLoader } from "@/managers/asset";
-import { ClientInteractive, ClientPositionable } from "@/extensions";
+import { ClientInteractive, ClientPlaceable, ClientPositionable } from "@/extensions";
 import Vector2 from "@shared/util/vector2";
 import { DEBUG_SHOW_ATTACK_RANGE } from "@shared/debug";
 import { getConfig } from "@shared/config";
@@ -25,7 +25,15 @@ export abstract class ClientEntity extends ClientEntityBase implements Renderabl
 
     if (myPlayer && interactive.getDisplayName()) {
       const displayName = formatDisplayName(interactive.getDisplayName());
-      let text = `${displayName} (${getConfig().keybindings.INTERACT})`;
+      const isPlaceable = this.hasExt(ClientPlaceable);
+
+      let text = displayName;
+      let interactMessage = "";
+      if (isPlaceable) {
+        interactMessage += "hold ";
+      }
+      interactMessage += `${getConfig().keybindings.INTERACT}`;
+      text += ` (${interactMessage})`;
 
       renderInteractionText(
         ctx,

--- a/packages/game-client/src/entities/player.ts
+++ b/packages/game-client/src/entities/player.ts
@@ -43,6 +43,7 @@ export class PlayerClient extends ClientEntity implements IClientEntity, Rendera
   private displayName: string = "";
   private stamina: number = 100;
   private maxStamina: number = 100;
+  private pickupProgress: number = 0;
   private serverGhostPos: Vector2 | null = null;
 
   private input: Input = {
@@ -85,6 +86,7 @@ export class PlayerClient extends ClientEntity implements IClientEntity, Rendera
     this.displayName = data.displayName || "Unknown";
     this.stamina = data.stamina ?? 100;
     this.maxStamina = data.maxStamina ?? 100;
+    this.pickupProgress = data.pickupProgress ?? 0;
   }
 
   private getPlayerAssetKey(): string {
@@ -468,5 +470,10 @@ export class PlayerClient extends ClientEntity implements IClientEntity, Rendera
     this.displayName = data.displayName || "Unknown";
     this.stamina = data.stamina ?? 100;
     this.maxStamina = data.maxStamina ?? 100;
+    this.pickupProgress = data.pickupProgress ?? 0;
+  }
+
+  getPickupProgress(): number {
+    return this.pickupProgress;
   }
 }

--- a/packages/game-client/src/extensions/index.ts
+++ b/packages/game-client/src/extensions/index.ts
@@ -12,6 +12,7 @@ import { ClientInteractive } from "@/extensions/interactive";
 import { ClientInventory } from "@/extensions/inventory";
 import { ClientMovable } from "@/extensions/movable";
 import { ClientPositionable } from "@/extensions/positionable";
+import { ClientPlaceable } from "@/extensions/placeable";
 import { ClientTriggerCooldownAttacker } from "@/extensions/trigger-cooldown-attacker";
 import { ClientTriggerable } from "@/extensions/triggerable";
 import { ClientUpdatable } from "@/extensions/updatable";
@@ -29,6 +30,7 @@ export const clientExtensionsMap = {
   [ExtensionTypes.COLLIDABLE]: ClientCollidable,
   [ExtensionTypes.CONSUMABLE]: ClientConsumable,
   [ExtensionTypes.CARRYABLE]: ClientCarryable,
+  [ExtensionTypes.PLACEABLE]: ClientPlaceable,
   [ExtensionTypes.COMBUSTIBLE]: ClientCombustible,
   [ExtensionTypes.GROUPABLE]: ClientGroupable,
   [ExtensionTypes.INVENTORY]: ClientInventory,
@@ -51,6 +53,7 @@ export {
   ClientCollidable,
   ClientConsumable,
   ClientCarryable,
+  ClientPlaceable,
   ClientCombustible,
   ClientGroupable,
   ClientInventory,

--- a/packages/game-client/src/extensions/placeable.ts
+++ b/packages/game-client/src/extensions/placeable.ts
@@ -1,0 +1,18 @@
+import { ClientExtensionSerialized } from "@/extensions/types";
+import { BaseClientExtension } from "./base-extension";
+import { ExtensionTypes } from "@shared/util/extension-types";
+
+/**
+ * ClientPlaceable extension marks entities that are structures placed on the ground
+ * (walls, spikes, mines, bear traps, etc.) as opposed to dropped items.
+ *
+ * This is used to determine if an item requires holding F to pick up.
+ * Placeable items require holding F, while regular droppable items are instant.
+ */
+export class ClientPlaceable extends BaseClientExtension {
+  public static readonly type = ExtensionTypes.PLACEABLE;
+
+  public deserialize(data: ClientExtensionSerialized): this {
+    return this;
+  }
+}

--- a/packages/game-server/src/entities/items/bear-trap.ts
+++ b/packages/game-server/src/entities/items/bear-trap.ts
@@ -4,6 +4,7 @@ import { Entities, Zombies, getZombieTypesSet } from "../../../../game-shared/sr
 import Positionable from "@/extensions/positionable";
 import Interactive from "@/extensions/interactive";
 import Carryable from "@/extensions/carryable";
+import Placeable from "@/extensions/placeable";
 import { IEntity } from "@/entities/types";
 import Destructible from "@/extensions/destructible";
 import OneTimeTrigger from "@/extensions/one-time-trigger";
@@ -36,6 +37,7 @@ export class BearTrap extends Entity implements IEntity {
       .setDisplayName("bear trap");
     this.addExtension(this.interactiveExtension);
     this.addExtension(new Carryable(this, "bear_trap" as any));
+    this.addExtension(new Placeable(this));
     this.addExtension(new Updatable(this, this.updateBearTrap.bind(this)));
 
     // Activate the trap when created

--- a/packages/game-server/src/entities/items/gasoline.ts
+++ b/packages/game-server/src/entities/items/gasoline.ts
@@ -4,6 +4,7 @@ import Destructible from "@/extensions/destructible";
 import Groupable from "@/extensions/groupable";
 import Interactive from "@/extensions/interactive";
 import Positionable from "@/extensions/positionable";
+import Placeable from "@/extensions/placeable";
 import { IGameManagers } from "@/managers/types";
 import { Entities } from "@/constants";
 import { Entity } from "@/entities/entity";
@@ -26,6 +27,7 @@ export class Gasoline extends Entity {
     this.addExtension(new Destructible(this).setMaxHealth(1).setHealth(itemState?.health ?? 1).onDeath(this.onDeath.bind(this)));
     this.addExtension(new Combustible(this, (type) => new Fire(gameManagers), 12, 64)); // More fires and larger spread than default
     this.addExtension(new Carryable(this, "gasoline").setItemState({ count }));
+    this.addExtension(new Placeable(this));
     this.addExtension(new Groupable(this, "enemy"));
   }
 

--- a/packages/game-server/src/entities/items/landmine.ts
+++ b/packages/game-server/src/entities/items/landmine.ts
@@ -5,6 +5,7 @@ import { getConfig } from "@shared/config";
 import Positionable from "@/extensions/positionable";
 import Interactive from "@/extensions/interactive";
 import Carryable from "@/extensions/carryable";
+import Placeable from "@/extensions/placeable";
 import { distance } from "../../../../game-shared/src/util/physics";
 import { IEntity } from "@/entities/types";
 import Destructible from "@/extensions/destructible";
@@ -40,6 +41,7 @@ export class Landmine extends Entity implements IEntity {
         .setDisplayName("landmine")
     );
     this.addExtension(new Carryable(this, "landmine").setItemState({ count }));
+    this.addExtension(new Placeable(this));
     this.addExtension(new Updatable(this, this.updateLandmine.bind(this)));
   }
 

--- a/packages/game-server/src/entities/items/sentry-gun.ts
+++ b/packages/game-server/src/entities/items/sentry-gun.ts
@@ -3,6 +3,7 @@ import Collidable from "@/extensions/collidable";
 import Destructible from "@/extensions/destructible";
 import Interactive from "@/extensions/interactive";
 import Positionable from "@/extensions/positionable";
+import Placeable from "@/extensions/placeable";
 import Updatable from "@/extensions/updatable";
 import { IGameManagers } from "@/managers/types";
 import { Entities, Zombies } from "@shared/constants";
@@ -48,6 +49,7 @@ export class SentryGun extends Entity {
         count,
       })
     );
+    this.addExtension(new Placeable(this));
     this.addExtension(new Updatable(this, this.updateSentryGun.bind(this)));
     this.addExtension(new Groupable(this, "friendly")); // Allied with player
   }

--- a/packages/game-server/src/entities/items/spikes.ts
+++ b/packages/game-server/src/entities/items/spikes.ts
@@ -1,6 +1,7 @@
 import Carryable from "@/extensions/carryable";
 import Interactive from "@/extensions/interactive";
 import Positionable from "@/extensions/positionable";
+import Placeable from "@/extensions/placeable";
 import TriggerCooldownAttacker from "@/extensions/trigger-cooldown-attacker";
 import { IGameManagers } from "@/managers/types";
 import { Entities } from "@/constants";
@@ -35,6 +36,7 @@ export class Spikes extends Entity {
       new Interactive(this).onInteract(this.interact.bind(this)).setDisplayName("spikes")
     );
     this.addExtension(new Carryable(this, "spikes").setItemState({ count }));
+    this.addExtension(new Placeable(this));
   }
 
   private interact(entityId: string): void {

--- a/packages/game-server/src/entities/items/torch.ts
+++ b/packages/game-server/src/entities/items/torch.ts
@@ -2,6 +2,7 @@ import Carryable from "@/extensions/carryable";
 import Illuminated from "@/extensions/illuminated";
 import Interactive from "@/extensions/interactive";
 import Positionable from "@/extensions/positionable";
+import Placeable from "@/extensions/placeable";
 import { IGameManagers } from "@/managers/types";
 import { Entities } from "@/constants";
 import { Entity } from "@/entities/entity";
@@ -16,6 +17,7 @@ export class Torch extends Entity {
     this.addExtension(new Positionable(this).setSize(Torch.Size));
     this.addExtension(new Interactive(this).onInteract(this.interact.bind(this)).setDisplayName("torch"));
     this.addExtension(new Carryable(this, "torch"));
+    this.addExtension(new Placeable(this));
     this.addExtension(new Illuminated(this, 200));
   }
 

--- a/packages/game-server/src/entities/items/wall.ts
+++ b/packages/game-server/src/entities/items/wall.ts
@@ -4,6 +4,7 @@ import Destructible from "@/extensions/destructible";
 import Interactive from "@/extensions/interactive";
 import Inventory from "@/extensions/inventory";
 import Positionable from "@/extensions/positionable";
+import Placeable from "@/extensions/placeable";
 import { IGameManagers } from "@/managers/types";
 import { Entities } from "@/constants";
 import { getConfig } from "@shared/config";
@@ -36,6 +37,7 @@ export class Wall extends Entity {
         count,
       })
     );
+    this.addExtension(new Placeable(this));
   }
 
   private interact(entityId: string): void {

--- a/packages/game-server/src/entities/player.ts
+++ b/packages/game-server/src/entities/player.ts
@@ -12,6 +12,7 @@ import Movable from "@/extensions/movable";
 import Positionable from "@/extensions/positionable";
 import Updatable from "@/extensions/updatable";
 import ResourcesBag from "@/extensions/resources-bag";
+import Placeable from "@/extensions/placeable";
 import { Broadcaster, IGameManagers } from "@/managers/types";
 import { Entities } from "@/constants";
 import { Direction } from "../../../game-shared/src/util/direction";
@@ -45,6 +46,7 @@ const PLAYER_SERIALIZABLE_FIELDS = [
   "input",
   "activeItem",
   "inventory",
+  "pickupProgress",
 ] as const;
 
 export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
@@ -54,6 +56,7 @@ export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
   private static readonly DROP_COOLDOWN = 0.25;
   private static readonly INTERACT_COOLDOWN = 0.25;
   private static readonly CONSUME_COOLDOWN = 0.5;
+  private static readonly PICKUP_HOLD_DURATION = 1.0; // 1 second in seconds
 
   // Internal state
   private fireCooldown = new Cooldown(0.4, true);
@@ -63,6 +66,9 @@ export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
   private broadcaster: Broadcaster;
   private lastWeaponType: ItemType | null = null;
   private exhaustionTimer: number = 0; // Time remaining before stamina can regenerate
+  // Item pickup hold tracking
+  private pickupHoldTimer: number = 0; // Time F has been held for pickup
+  private targetPickupEntity: string | null = null; // Entity ID being targeted for pickup
 
   // Serializable fields (base class will access these directly)
   private input: Input = {
@@ -84,6 +90,7 @@ export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
   private displayName: string = "";
   private stamina: number = getConfig().player.MAX_STAMINA;
   private maxStamina: number = getConfig().player.MAX_STAMINA;
+  private pickupProgress: number = 0; // 0-1 value representing pickup progress
 
   constructor(gameManagers: IGameManagers) {
     super(gameManagers, Entities.PLAYER);
@@ -442,7 +449,11 @@ export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
   handleInteract(deltaTime: number) {
     this.interactCooldown.update(deltaTime);
 
-    if (!this.input.interact) return;
+    if (!this.input.interact) {
+      this.pickupHoldTimer = 0;
+      this.targetPickupEntity = null;
+      return;
+    }
 
     if (this.interactCooldown.isReady()) {
       this.interactCooldown.reset();
@@ -465,6 +476,7 @@ export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
           entity,
           distance: distance(playerPos, entityPos),
           isDeadPlayer: entity.getType() === Entities.PLAYER && (entity as Player).isDead(),
+          isPlaceable: entity.hasExt(Placeable),
         };
       });
 
@@ -478,8 +490,26 @@ export class Player extends Entity<typeof PLAYER_SERIALIZABLE_FIELDS> {
       });
 
       // Get the closest entity (already filtered and sorted)
-      const closestEntity = entityData[0].entity;
-      closestEntity.getExt(Interactive).interact(this.getId());
+      const closestEntity = entityData[0];
+
+      const now = new Date().getTime();
+      if (this.pickupHoldTimer == 0) {
+        this.pickupHoldTimer = now;
+      }
+      let timeSincePickup = now - this.pickupHoldTimer;
+      this.targetPickupEntity = closestEntity.entity.getId();
+
+      if (closestEntity.isPlaceable) {
+        if (timeSincePickup >= Player.PICKUP_HOLD_DURATION) {
+          closestEntity.entity.getExt(Interactive).interact(this.getId());
+          this.pickupHoldTimer = 0;
+          this.targetPickupEntity = null;
+        }
+      } else {
+        closestEntity.entity.getExt(Interactive).interact(this.getId());
+        this.pickupHoldTimer = 0;
+        this.targetPickupEntity = null;
+      }
     }
   }
 

--- a/packages/game-server/src/extensions/index.ts
+++ b/packages/game-server/src/extensions/index.ts
@@ -13,6 +13,7 @@ import Movable from "@/extensions/movable";
 import Combustible from "@/extensions/combustible";
 import Illuminated from "@/extensions/illuminated";
 import Carryable from "@/extensions/carryable";
+import Placeable from "@/extensions/placeable";
 import Groupable from "@/extensions/groupable";
 import Snared from "@/extensions/snared";
 import ResourcesBag from "@/extensions/resources-bag";
@@ -33,6 +34,7 @@ export const extensionsMap = {
   [Combustible.type]: Combustible,
   [Illuminated.type]: Illuminated,
   [Carryable.type]: Carryable,
+  [Placeable.type]: Placeable,
   [Groupable.type]: Groupable,
   [Snared.type]: Snared,
   [ResourcesBag.type]: ResourcesBag,

--- a/packages/game-server/src/extensions/placeable.ts
+++ b/packages/game-server/src/extensions/placeable.ts
@@ -1,0 +1,48 @@
+import { Extension, ExtensionSerialized } from "@/extensions/types";
+import { IEntity } from "@/entities/types";
+
+/**
+ * Placeable extension marks entities that are structures placed on the ground
+ * (walls, spikes, mines, bear traps, etc.) as opposed to dropped items.
+ * 
+ * This is used to determine if an item requires holding F to pick up.
+ * Placeable items require holding F, while regular droppable items are instant.
+ */
+export default class Placeable implements Extension {
+  public static readonly type = "placeable" as const;
+
+  private self: IEntity;
+  private dirty: boolean = false;
+
+  public constructor(self: IEntity) {
+    this.self = self;
+  }
+
+  public isDirty(): boolean {
+    return this.dirty;
+  }
+
+  public markDirty(): void {
+    this.dirty = true;
+    if (this.self.markExtensionDirty) {
+      this.self.markExtensionDirty(this);
+    }
+  }
+
+  public clearDirty(): void {
+    this.dirty = false;
+  }
+
+  public serializeDirty(): ExtensionSerialized | null {
+    if (!this.dirty) {
+      return null;
+    }
+    return this.serialize();
+  }
+
+  public serialize(): ExtensionSerialized {
+    return {
+      type: Placeable.type,
+    };
+  }
+}

--- a/packages/game-shared/src/util/extension-types.ts
+++ b/packages/game-shared/src/util/extension-types.ts
@@ -15,6 +15,7 @@ export const ExtensionTypes = {
   COMBUSTIBLE: "combustible",
   ILLUMINATED: "illuminated",
   CARRYABLE: "carryable",
+  PLACEABLE: "placeable",
   GROUPABLE: "groupable",
   LANDMINE_UPDATE: "landmine-update",
   ONE_TIME_TRIGGER: "one-time-trigger",


### PR DESCRIPTION
1) Added a "palceable" extension for the items that can be placed on the ground
2) added a delay of 1 second for those items to be picked up when holding F

**What issue does it solve?**
I've been playing and it really bothers me when I place spikes/walls and the loot also gets inside those entities and when I go to pick them up by spamming F it picks up the spieks/walls too, which was really annoying, so I added a delay for the items that are placeable

TODO: I really couldn't understand yet how to draw some stuff, would be good to also display a spinner on the item that the player is trying to pick up when holding F