### PR TITLE
Ammo invenotry

### DIFF
--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -21,7 +21,7 @@ import { Direction } from "../../game-shared/src/util/direction";
 import { Input } from "../../game-shared/src/util/input";
 import { ClientEntityBase } from "@/extensions/client-entity";
 import { ClientDestructible } from "@/extensions/destructible";
-import { ClientPositionable, ClientResourcesBag } from "@/extensions";
+import { ClientPositionable, ClientResourcesBag, ClientInventory } from "@/extensions";
 import { CampsiteFireClient } from "@/entities/environment/campsite-fire";
 import { WaveState } from "@shared/types/wave";
 import { ParticleManager } from "./managers/particles";
@@ -895,12 +895,25 @@ export class GameClient {
       cloth = resourcesBag.getCloth();
     }
 
+    // Get ammo from inventory extension and add to inventory for crafting checks
+    // IMPORTANT: Create a copy so we don't modify the actual inventory
+    const inventoryItems = [...player.getInventory()];
+    if (player.hasExt(ClientInventory)) {
+      const ammo = player.getExt(ClientInventory).getAllAmmo();
+      // Add ammo as inventory items so recipes can check them
+      for (const [ammoType, count] of Object.entries(ammo)) {
+        if (typeof count === "number" && count > 0) {
+          inventoryItems.push({ itemType: ammoType, state: { count: count } });
+        }
+      }
+    }
+
     return {
       resources: {
         wood,
         cloth,
       },
-      inventory: player.getInventory(),
+      inventory: inventoryItems,
       playerId: this.gameState.playerId,
     };
   }

--- a/packages/game-client/src/extensions/inventory.ts
+++ b/packages/game-client/src/extensions/inventory.ts
@@ -8,6 +8,8 @@ export class ClientInventory extends BaseClientExtension {
   public static readonly MAX_SLOTS = 8;
 
   private items: InventoryItem[] = [];
+  // Separate ammo storage: { ammoType: count }
+  private ammo: Record<string, number> = {};
 
   public getItems(): InventoryItem[] {
     return this.items;
@@ -27,9 +29,25 @@ export class ClientInventory extends BaseClientExtension {
     return isWeapon(activeItem.itemType) ? activeItem : null;
   }
 
+  // Ammo management methods
+  public getAmmo(ammoType: string): number {
+    return this.ammo[ammoType] || 0;
+  }
+
+  public hasAmmo(ammoType: string): boolean {
+    return this.getAmmo(ammoType) > 0;
+  }
+
+  public getAllAmmo(): Record<string, number> {
+    return { ...this.ammo };
+  }
+
   public deserialize(data: ClientExtensionSerialized): this {
     if (data.items) {
       this.items = data.items;
+    }
+    if (data.ammo) {
+      this.ammo = data.ammo;
     }
     return this;
   }

--- a/packages/game-client/src/ui/inventory-bar.ts
+++ b/packages/game-client/src/ui/inventory-bar.ts
@@ -1,14 +1,16 @@
-import { GameState } from "@/state";
+import { GameState, getEntityById } from "@/state";
 import { InputManager } from "@/managers/input";
 import { Z_INDEX } from "@shared/map";
 import { Renderable } from "@/entities/util";
 import { AssetManager, getItemAssetKey } from "@/managers/asset";
-import { InventoryItem } from "../../../game-shared/src/util/inventory";
+import { getAmmoForWeapon, InventoryItem } from "@shared/util/inventory";
 import { getConfig } from "@shared/config";
 import { HeartsPanel } from "./panels/hearts-panel";
 import { StaminaPanel } from "./panels/stamina-panel";
 import { calculateHudScale } from "@/util/hud-scale";
 import { formatDisplayName } from "@/util/format";
+import { PlayerClient } from "@/entities/player";
+import { ClientInventory } from "@/extensions/inventory";
 
 const HOTBAR_SETTINGS = {
   Inventory: {
@@ -296,6 +298,31 @@ export class InventoryBarUI implements Renderable {
         const countY = slotsBottom - 6 * hudScale;
         ctx.strokeText(`${inventoryItem.state.count}`, countX, countY);
         ctx.fillText(`${inventoryItem.state.count}`, countX, countY);
+      }
+
+      // Draw ammo count for weapons
+      if (inventoryItem && !inventoryItem.state?.count) {
+        const ammoType = getAmmoForWeapon(inventoryItem.itemType);
+        if (ammoType) {
+          // Get the player to access ammo inventory
+          const player = getEntityById(gameState, gameState.playerId) as PlayerClient;
+          if (player && player.hasExt(ClientInventory)) {
+            const inventory = player.getExt(ClientInventory);
+            const ammoCount = inventory.getAmmo(ammoType);
+
+            // Display ammo count in bottom-right corner
+            const ammoFontSize = 18 * hudScale;
+            ctx.font = `bold ${ammoFontSize}px Arial`;
+            ctx.textAlign = "right";
+            ctx.fillStyle = ammoCount > 0 ? "yellow" : "red";
+            ctx.strokeStyle = "rgba(0, 0, 0, 0.8)";
+            ctx.lineWidth = 3 * hudScale;
+            const ammoX = slotRight - 4 * hudScale;
+            const ammoY = slotsBottom - 4 * hudScale;
+            ctx.strokeText(`${ammoCount}`, ammoX, ammoY);
+            ctx.fillText(`${ammoCount}`, ammoX, ammoY);
+          }
+        }
       }
     }
 

--- a/packages/game-server/src/entities/weapons/helpers.ts
+++ b/packages/game-server/src/entities/weapons/helpers.ts
@@ -44,24 +44,6 @@ export function knockBack(
  * Returns true if ammo was successfully consumed, false otherwise.
  */
 export function consumeAmmo(inventory: Inventory, ammoType: string): boolean {
-  // TODO: item? the item should never be undefined
-  const ammoItem = inventory.getItems().find((item) => item?.itemType === ammoType);
-
-  if (!ammoItem || !ammoItem.state?.count || ammoItem.state.count <= 0) {
-    return false;
-  }
-
-  const ammoIndex = inventory.getItems().findIndex((item) => item?.itemType === ammoType);
-  if (ammoIndex === -1) {
-    // This shouldn't happen since we found ammoItem, but handle it gracefully
-    return false;
-  }
-
-  inventory.updateItemState(ammoIndex, { count: ammoItem.state.count - 1 });
-
-  if (ammoItem.state.count <= 0) {
-    inventory.removeItem(ammoIndex);
-  }
-
-  return true;
+  // Use the inventory's consumeAmmo method which works with the separate ammo storage
+  return inventory.consumeAmmo(ammoType, 1);
 }

--- a/packages/game-server/src/extensions/carryable.ts
+++ b/packages/game-server/src/extensions/carryable.ts
@@ -1,7 +1,7 @@
 import { Extension, ExtensionSerialized } from "@/extensions/types";
 import { PlayerPickedUpItemEvent } from "@/events/server-sent/pickup-item-event";
 import Inventory from "@/extensions/inventory";
-import { ItemType } from "@/util/inventory";
+import { ItemType, isAmmo } from "@/util/inventory";
 import { IEntity } from "@/entities/types";
 import { ItemState } from "@/types/entity";
 
@@ -68,7 +68,10 @@ export default class Carryable implements Extension {
 
     const inventory = entity.getExt(Inventory);
 
-    if (inventory.isFull() && !options?.mergeStrategy) {
+    // Ammo items don't take up inventory slots, so they can always be picked up
+    const isAmmoItem = isAmmo(this.itemType);
+
+    if (!isAmmoItem && inventory.isFull() && !options?.mergeStrategy) {
       return false;
     }
 
@@ -89,7 +92,8 @@ export default class Carryable implements Extension {
     }
 
     // Otherwise add as new item
-    if (inventory.isFull()) {
+    // Ammo can always be added (doesn't take inventory slots)
+    if (!isAmmoItem && inventory.isFull()) {
       return false;
     }
 

--- a/packages/game-server/src/managers/server-socket-manager.ts
+++ b/packages/game-server/src/managers/server-socket-manager.ts
@@ -7,7 +7,7 @@ import { GameServer } from "@/server";
 import { AdminCommand } from "@shared/commands/commands";
 import { Input } from "../../../game-shared/src/util/input";
 import { RecipeType } from "../../../game-shared/src/util/recipes";
-import { ItemType, isResourceItem, ResourceType } from "@shared/util/inventory";
+import { ItemType, isResourceItem, ResourceType, isAmmo } from "@shared/util/inventory";
 import { itemRegistry } from "@shared/entities/item-registry";
 import Vector2 from "@/util/vector2";
 import { createServer } from "http";
@@ -302,8 +302,9 @@ export class ServerSocketManager implements Broadcaster {
       const item = { itemType };
       const inventory = player.getExt(Inventory);
 
-      // Add to inventory or drop on ground
-      if (inventory.isFull()) {
+      // Ammo doesn't take up inventory slots, so it can always be added
+      // Regular items need to check if inventory is full
+      if (!isAmmo(itemType) && inventory.isFull()) {
         // Drop item 32 pixels down from player
         const playerPos = player.getExt(Positionable).getPosition();
         const dropPosition = new Vector2(playerPos.x, playerPos.y + 32);

--- a/packages/game-shared/src/util/inventory.ts
+++ b/packages/game-shared/src/util/inventory.ts
@@ -34,3 +34,31 @@ export function isResourceItem(itemType: ItemType): boolean {
 export function isWeapon(itemType: ItemType): boolean {
   return weaponRegistry.has(itemType);
 }
+
+/**
+ * Check if an item type is ammo by checking if it ends with "_ammo"
+ */
+export function isAmmo(itemType: ItemType): boolean {
+  return itemType.endsWith("_ammo");
+}
+
+/**
+ * Get the weapon type for a given ammo type.
+ * For example: "pistol_ammo" -> "pistol"
+ */
+export function getWeaponForAmmo(ammoType: ItemType): ItemType | null {
+  if (!isAmmo(ammoType)) return null;
+  return ammoType.replace("_ammo", "");
+}
+
+/**
+ * Get the ammo type for a given weapon type.
+ * For example: "pistol" -> "pistol_ammo"
+ */
+export function getAmmoForWeapon(weaponType: ItemType): ItemType | null {
+  if (!isWeapon(weaponType)) return null;
+  // Melee weapons don't use ammo
+  const config = weaponRegistry.get(weaponType);
+  if (config?.type === "melee") return null;
+  return `${weaponType}_ammo`;
+}


### PR DESCRIPTION
Added ammo into a separate inventory pretty much, removed from inventory-bar.

**What this improves?**
When playing the ammo literally takes up so much space in your inventory that you can't really hold too many items or guns that you want, i feel like this will make the gameplay much better and people will play with different guns.

Also, before, I used to just drop the ammo in bushes so they don't get stuck in my inventory so I can pick up other items, which was quite annoying.