### PR TITLE
automatically remove entities

### DIFF
--- a/packages/game-server/src/entities/enemies/base-enemy.ts
+++ b/packages/game-server/src/entities/enemies/base-enemy.ts
@@ -139,6 +139,9 @@ export abstract class BaseEnemy extends Entity<typeof BASE_ENEMY_SERIALIZABLE_FI
 
     // Spawn a coin when zombie dies
     this.spawnCoin();
+
+    // Mark entity for removal if not looted
+    this.getEntityManager().markEntityForRemoval(this, getConfig().entity.ENTITY_DESPAWN_TIME_MS);
   }
 
   spawnCoin(): void {

--- a/packages/game-server/src/entities/environment/survivor.ts
+++ b/packages/game-server/src/entities/environment/survivor.ts
@@ -354,6 +354,9 @@ export class Survivor extends Entity<typeof SERIALIZABLE_FIELDS> {
 
     // Disable collision
     this.getExt(Collidable).setEnabled(false);
+
+    // Mark entity for removal if not looted
+    this.getEntityManager().markEntityForRemoval(this, getConfig().entity.ENTITY_DESPAWN_TIME_MS);
   }
 
   private onLooted(): void {

--- a/packages/game-server/src/entities/items/coin.ts
+++ b/packages/game-server/src/entities/items/coin.ts
@@ -5,6 +5,8 @@ import { Entities, PLAYER_TYPES } from "@/constants";
 import { Entity } from "@/entities/entity";
 import Vector2 from "@/util/vector2";
 import { CoinPickupEvent } from "@shared/events/server-sent/coin-pickup-event";
+import { getConfig } from "@shared/config";
+
 export class Coin extends Entity {
   public static readonly Size = new Vector2(16, 16);
   private static readonly TRIGGER_RADIUS = 16;
@@ -19,6 +21,9 @@ export class Coin extends Entity {
         targetTypes: [Entities.PLAYER],
       }).onTrigger(() => this.collect())
     );
+
+    // Mark coin for removal if not collected
+    this.getEntityManager().markEntityForRemoval(this, getConfig().entity.ENTITY_DESPAWN_TIME_MS);
   }
 
   private collect(): void {

--- a/packages/game-server/src/managers/types.ts
+++ b/packages/game-server/src/managers/types.ts
@@ -8,7 +8,7 @@ import { EntityStateTracker } from "./entity-state-tracker";
 export interface IEntityManager {
   generateEntityId(): string;
   addEntity(entity: IEntity): void;
-  markEntityForRemoval(entity: IEntity): void;
+  markEntityForRemoval(entity: IEntity, expiration?: number): void;
   removeEntity(entityId: string): void;
   createEntityFromItem(item: InventoryItem): IEntity | null;
   isColliding(entity: IEntity, IEntityTypes?: EntityType[]): IEntity | null;

--- a/packages/game-shared/src/config/entity-config.ts
+++ b/packages/game-shared/src/config/entity-config.ts
@@ -1,0 +1,12 @@
+/**
+ * ========================================================================
+ * COMBAT CONFIGURATION
+ * ========================================================================
+ * Combat ranges, weapon stats, and damage settings
+ */
+
+export const entityConfig = {
+  ENTITY_DESPAWN_TIME_MS: 1000 * 120, // 2 minutes
+} as const;
+
+export type EntityConfig = typeof entityConfig;

--- a/packages/game-shared/src/config/entity-config.ts
+++ b/packages/game-shared/src/config/entity-config.ts
@@ -1,8 +1,8 @@
 /**
  * ========================================================================
- * COMBAT CONFIGURATION
+ * ENTITY CONFIGURATION
  * ========================================================================
- * Combat ranges, weapon stats, and damage settings
+ * Everything about entities
  */
 
 export const entityConfig = {

--- a/packages/game-shared/src/config/index.ts
+++ b/packages/game-shared/src/config/index.ts
@@ -23,6 +23,7 @@ import { merchantConfig, type MerchantConfig } from "./merchant-config";
 import { predictionConfig, type PredictionConfig } from "./prediction";
 import { networkConfig, type NetworkConfig } from "./network";
 import { renderConfig, type RenderConfig } from "./render-config";
+import { entityConfig, EntityConfig } from "@/config/entity-config";
 /**
  * Combined game configuration object
  */
@@ -39,6 +40,7 @@ export interface GameConfig {
   prediction: PredictionConfig;
   network: NetworkConfig;
   render: RenderConfig;
+  entity: EntityConfig;
 }
 
 /**
@@ -57,6 +59,7 @@ const defaultConfig: GameConfig = {
   prediction: predictionConfig,
   network: networkConfig,
   render: renderConfig,
+  entity: entityConfig,
 };
 
 /**


### PR DESCRIPTION
Remove zombies,survivors,coins after 2 minutes if not looted.

Sometimes when we are at wave 10+ there are many zombies not getting looted and they just stay there forever nobody wants to loot them anyways, I think if we don't loot them in 2 minutes or depends on how much we set it they should disappear.