### PR TITLE
fix(initial-screen): do not toggle game instructions when user's typing

### DIFF
--- a/packages/website/app/routes/play.tsx
+++ b/packages/website/app/routes/play.tsx
@@ -73,7 +73,8 @@ function GameClientLoader() {
         return;
       }
 
-      if (e.key === "i" || e.key === "I") {
+      // Don't toggle instructions if user is typing username
+      if (gameClient && (e.key === "i" || e.key === "I")) {
         setShowInstructions((prev) => !prev);
       }
     };


### PR DESCRIPTION
Removes "Game Instructions" toggle when typing username on the initial screen.
