### PR TITLE
Add extended inventory system with drag and drop

### DIFF
--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -193,6 +193,11 @@ export class GameClient {
         return; // Click was handled by merchant panel
       }
 
+      // Update shift key state for quick move feature
+      if (this.hud) {
+        this.hud.setShiftHeld(e.shiftKey);
+      }
+
       // Handle UI clicks (inventory bar, HUD mute button, etc.)
       // HUD handles both hotbar and other UI clicks
       if (this.hud && this.hud.handleClick(x, y, canvas.width, canvas.height)) {
@@ -360,6 +365,7 @@ export class GameClient {
       getInventory,
       isMerchantPanelOpen: () => this.merchantBuyPanel.isVisible(),
       isFullscreenMapOpen: () => this.hud.isFullscreenMapOpen(),
+      isInventoryPanelOpen: () => this.hud.isInventoryPanelOpen(),
       onToggleInstructions: () => {
         this.hud.toggleInstructions();
       },
@@ -388,6 +394,9 @@ export class GameClient {
       },
       onToggleMap: () => {
         this.hud.toggleFullscreenMap();
+      },
+      onToggleInventory: () => {
+        this.hud.toggleInventoryPanel();
       },
       onDown: (inputs: Input) => {
         inputs.dy = 1;

--- a/packages/game-client/src/managers/input.ts
+++ b/packages/game-client/src/managers/input.ts
@@ -30,6 +30,7 @@ export interface InputManagerOptions {
   onSendChat?: () => void;
   onToggleMute?: () => void;
   onToggleMap?: () => void;
+  onToggleInventory?: () => void;
   onMerchantKeyDown?: (key: string) => void;
   onEscape?: () => void;
   onRespawnRequest?: () => void;
@@ -38,6 +39,7 @@ export interface InputManagerOptions {
   onWeaponSelectByIndex?: (index: number) => void;
   isMerchantPanelOpen?: () => boolean;
   isFullscreenMapOpen?: () => boolean;
+  isInventoryPanelOpen?: () => boolean;
   isPlayerDead?: () => boolean;
   getInventory?: () => any[];
   onInventorySlotChanged?: (slot: number) => void;
@@ -268,23 +270,8 @@ export class InputManager {
           break;
         }
         case "KeyX": {
-          // Split half of the currently selected stack (if stackable)
-          const splitSlot = this.currentInventorySlot - 1; // Convert to 0-indexed
-          if (splitSlot < 0) break;
-
-          const inventory = callbacks.getInventory?.();
-          if (!inventory) break;
-
-          const item = inventory[splitSlot];
-          if (!item) break;
-
-          const count = item.state?.count ?? 1;
-          if (count <= 1) break;
-
-          const dropAmount = Math.floor(count / 2);
-          if (dropAmount <= 0) break;
-
-          callbacks.onDropItem?.(splitSlot, dropAmount);
+          // Toggle inventory panel
+          callbacks.onToggleInventory?.();
           break;
         }
         case "Space":

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -22,6 +22,7 @@ import { getConfig } from "@shared/config";
 import { scaleHudValue, calculateHudScale } from "@/util/hud-scale";
 import { GameOverDialogUI } from "./game-over-dialog";
 import { InventoryBarUI } from "./inventory-bar";
+import { InventoryPanelUI } from "./inventory-panel";
 import { WeaponsHUD } from "@/ui/weapons-hud";
 import { InputManager } from "@/managers/input";
 import { PlayerClient } from "@/entities/player";
@@ -154,12 +155,14 @@ export class Hud {
   private survivorIndicatorsPanel: SurvivorIndicatorsPanel;
   private gameOverDialog: GameOverDialogUI;
   private hotbar: InventoryBarUI;
+  private inventoryPanel: InventoryPanelUI;
   private weaponsHud: WeaponsHUD;
   private inputManager: InputManager;
   private currentGameState: GameState | null = null;
   private mouseX: number = 0;
   private mouseY: number = 0;
   private canvasHeight: number = 0;
+  private shiftHeld: boolean = false;
 
   constructor(
     mapManager: MapManager,
@@ -198,6 +201,14 @@ export class Hud {
       this.inputManager,
       getInventory,
       sendDropItem,
+      sendSwapItems
+    );
+
+    // Initialize inventory panel (extended inventory)
+    this.inventoryPanel = new InventoryPanelUI(
+      this.assetManager,
+      this.inputManager,
+      getInventory,
       sendSwapItems
     );
 
@@ -370,6 +381,14 @@ export class Hud {
     return this.fullscreenMap.isOpen();
   }
 
+  public toggleInventoryPanel(): void {
+    this.inventoryPanel.toggle();
+  }
+
+  public isInventoryPanelOpen(): boolean {
+    return this.inventoryPanel.isVisible();
+  }
+
   private getPingColor(ping: number): string {
     if (ping < 50) return HUD_SETTINGS.BottomRightPanels.pingColors.excellent;
     if (ping < 100) return HUD_SETTINGS.BottomRightPanels.pingColors.good;
@@ -525,6 +544,9 @@ export class Hud {
     // Render hotbar
     this.hotbar.render(ctx, gameState);
 
+    // Render inventory panel (extended inventory)
+    this.inventoryPanel.render(ctx, gameState);
+
     // Render death screen if player is dead and game is not over
     if (!this.gameOverDialog.isGameOver()) {
       this.deathScreenPanel.render(ctx, gameState);
@@ -626,7 +648,9 @@ export class Hud {
   }
 
   public isHoveringInventory(): boolean {
-    return this.hotbar ? this.hotbar.isHovering() : false;
+    const hotbarHover = this.hotbar ? this.hotbar.isHovering() : false;
+    const panelHover = this.inventoryPanel ? this.inventoryPanel.isHovering() : false;
+    return hotbarHover || panelHover;
   }
 
   public isHoveringMuteButton(): boolean {
@@ -636,6 +660,11 @@ export class Hud {
   public handleClick(x: number, y: number, canvasWidth: number, canvasHeight: number): boolean {
     // Check fullscreen map clicks first (if open)
     if (this.fullscreenMap.handleClick(x, y)) {
+      return true;
+    }
+
+    // Check if click is on inventory panel (if open)
+    if (this.inventoryPanel && this.inventoryPanel.handleClick(x, y, canvasWidth, canvasHeight, this.shiftHeld)) {
       return true;
     }
 
@@ -650,16 +679,24 @@ export class Hud {
     }
 
     // Check if click is on hotbar
-    if (this.hotbar && this.hotbar.handleClick(x, y, canvasWidth, canvasHeight)) {
+    if (this.hotbar && this.hotbar.handleClick(x, y, canvasWidth, canvasHeight, this.shiftHeld)) {
       return true;
     }
 
     return false; // Click was not handled
   }
 
+  public setShiftHeld(held: boolean): void {
+    this.shiftHeld = held;
+  }
+
   public handleMouseMove(x: number, y: number, canvasWidth: number, canvasHeight: number): void {
     if (this.hotbar) {
       this.hotbar.handleMouseMove(x, y, canvasWidth, canvasHeight);
+    }
+
+    if (this.inventoryPanel) {
+      this.inventoryPanel.handleMouseMove(x, y, canvasWidth, canvasHeight);
     }
 
     // Forward mouse move to fullscreen map for drag handling
@@ -669,8 +706,35 @@ export class Hud {
   }
 
   public handleMouseUp(x: number, y: number, canvasWidth: number, canvasHeight: number): void {
+    // Handle cross-drag from hotbar to inventory panel
+    if (this.hotbar && this.inventoryPanel && this.inventoryPanel.isVisible()) {
+      const hotbarDragState = (this.hotbar as any).dragState;
+      if (hotbarDragState?.isDragging) {
+        const handled = this.inventoryPanel.handleExternalDrop(hotbarDragState.slotIndex, x, y);
+        if (handled) {
+          (this.hotbar as any).dragState = null;
+          return;
+        }
+      }
+    }
+
+    // Handle cross-drag from inventory panel to hotbar
+    if (this.inventoryPanel && this.hotbar && this.inventoryPanel.isDragging()) {
+      const panelDragState = this.inventoryPanel.getDragState();
+      if (panelDragState?.isDragging) {
+        const handled = (this.hotbar as any).handleExternalDrop?.(panelDragState.slotIndex, x, y);
+        if (handled) {
+          return;
+        }
+      }
+    }
+
     if (this.hotbar) {
       this.hotbar.handleMouseUp(x, y, canvasWidth, canvasHeight);
+    }
+
+    if (this.inventoryPanel) {
+      this.inventoryPanel.handleMouseUp(x, y, canvasWidth, canvasHeight);
     }
 
     // Forward mouse up to fullscreen map for drag handling
@@ -691,6 +755,9 @@ export class Hud {
 
     if (this.hotbar) {
       this.hotbar.updateMousePosition(x, y, canvasWidth, canvasHeight);
+    }
+    if (this.inventoryPanel) {
+      this.inventoryPanel.updateMousePosition(x, y, canvasWidth, canvasHeight);
     }
     if (this.weaponsHud) {
       this.weaponsHud.updateMouse(x, y);

--- a/packages/game-client/src/ui/inventory-bar.ts
+++ b/packages/game-client/src/ui/inventory-bar.ts
@@ -200,7 +200,7 @@ export class InventoryBarUI implements Renderable {
     this.hoveredSlot = this.getSlotIndexAtPosition(x, y, metrics);
   }
 
-  public handleClick(x: number, y: number, canvasWidth: number, canvasHeight: number): boolean {
+  public handleClick(x: number, y: number, canvasWidth: number, canvasHeight: number, shiftHeld: boolean = false): boolean {
     this.lastCanvasWidth = canvasWidth;
     this.lastCanvasHeight = canvasHeight;
 
@@ -216,10 +216,51 @@ export class InventoryBarUI implements Renderable {
       return false; // Click was not on inventory
     }
 
+    // Shift+click: quick move to inventory panel
+    if (shiftHeld) {
+      const items = this.getInventory();
+      const item = items[slotIndex];
+      if (item) {
+        const targetSlot = this.findTargetSlotInInventory(slotIndex, items);
+        if (targetSlot !== null) {
+          this.sendSwapItems(slotIndex, targetSlot);
+          return true;
+        }
+      }
+    }
+
     // Click is on slot i, select it (convert to 1-indexed)
     this.inputManager.setInventorySlot(slotIndex + 1);
     this.prepareDragState(slotIndex, x, y);
     return true;
+  }
+
+  // Find target slot in extended inventory for quick move
+  private findTargetSlotInInventory(fromSlot: number, items: InventoryItem[]): number | null {
+    const hotbarSlots = getConfig().player.HOTBAR_SLOTS;
+    const maxSlots = getConfig().player.MAX_INVENTORY_SLOTS;
+    
+    // Preferred slot: corresponding position in inventory (slot 0 -> 10, slot 1 -> 11, etc.)
+    const preferredSlot = hotbarSlots + fromSlot;
+    
+    // If preferred slot is empty or within range, use it
+    if (preferredSlot < maxSlots && !items[preferredSlot]) {
+      return preferredSlot;
+    }
+    
+    // Otherwise find first empty slot in inventory range
+    for (let i = hotbarSlots; i < maxSlots; i++) {
+      if (!items[i]) {
+        return i;
+      }
+    }
+    
+    // No empty slot, swap with preferred slot anyway
+    if (preferredSlot < maxSlots) {
+      return preferredSlot;
+    }
+    
+    return null;
   }
 
   public handleMouseMove(x: number, y: number, canvasWidth?: number, canvasHeight?: number): void {
@@ -294,7 +335,7 @@ export class InventoryBarUI implements Renderable {
     // Scale inventory bar based on screen width for responsive design
     const hudScale = calculateHudScale(canvasWidth, canvasHeight);
     const settings = HOTBAR_SETTINGS.Inventory;
-    const slotsNumber = getConfig().player.MAX_INVENTORY_SLOTS;
+    const slotsNumber = getConfig().player.HOTBAR_SLOTS;
 
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
@@ -471,7 +512,7 @@ export class InventoryBarUI implements Renderable {
     const { width: canvasWidth, height: canvasHeight } = ctx.canvas;
     const hudScale = calculateHudScale(canvasWidth, canvasHeight);
     const settings = HOTBAR_SETTINGS.Inventory;
-    const slotsNumber = getConfig().player.MAX_INVENTORY_SLOTS;
+    const slotsNumber = getConfig().player.HOTBAR_SLOTS;
 
     ctx.save();
     ctx.setTransform(1, 0, 0, 1, 0, 0);
@@ -614,7 +655,7 @@ export class InventoryBarUI implements Renderable {
   private calculateHotbarMetrics(canvasWidth: number, canvasHeight: number): HotbarMetrics {
     const hudScale = calculateHudScale(canvasWidth, canvasHeight);
     const cfg = HOTBAR_SETTINGS.Inventory;
-    const slots = getConfig().player.MAX_INVENTORY_SLOTS;
+    const slots = getConfig().player.HOTBAR_SLOTS;
 
     // Scale only what is actually needed
     const slotSize = cfg.slotSize * hudScale;
@@ -669,5 +710,21 @@ export class InventoryBarUI implements Renderable {
       y >= metrics.hotbarY &&
       y <= metrics.hotbarY + metrics.hotbarHeight
     );
+  }
+
+  // Handle external drag from inventory panel ending on this hotbar
+  public handleExternalDrop(fromSlotIndex: number, x: number, y: number): boolean {
+    const metrics = this.getHotbarMetrics(this.lastCanvasWidth, this.lastCanvasHeight);
+    if (!metrics) return false;
+
+    if (!this.isPointInsideHotbar(x, y, metrics)) return false;
+
+    const targetSlotIndex = this.getSlotIndexAtPosition(x, y, metrics);
+    if (targetSlotIndex !== null) {
+      this.sendSwapItems(fromSlotIndex, targetSlotIndex);
+      return true;
+    }
+
+    return false;
   }
 }

--- a/packages/game-client/src/ui/inventory-panel.ts
+++ b/packages/game-client/src/ui/inventory-panel.ts
@@ -1,0 +1,671 @@
+import { GameState } from "@/state";
+import { InputManager } from "@/managers/input";
+import { Z_INDEX } from "@shared/map";
+import { Renderable } from "@/entities/util";
+import { AssetManager, getItemAssetKey } from "@/managers/asset";
+import {
+  InventoryItem,
+  isWeapon,
+  getWeaponAmmoType,
+} from "../../../game-shared/src/util/inventory";
+import { getConfig } from "@shared/config";
+import { calculateHudScale } from "@/util/hud-scale";
+import { formatDisplayName } from "@/util/format";
+
+const INVENTORY_PANEL_SETTINGS = {
+  columns: 8,
+  rows: 2,
+  slotSize: 60,
+  slotsGap: 8,
+  padding: {
+    top: 12,
+    bottom: 12,
+    left: 12,
+    right: 12,
+  },
+  containerBackground: "rgba(0, 0, 0, 0.85)",
+  slotBackground: "rgba(40, 40, 40, 0.9)",
+  borderColor: "rgba(255, 255, 255, 0.5)",
+  activeBorderColor: "rgba(255, 255, 255, 0.9)",
+  borderWidth: 2,
+  headerHeight: 32,
+  headerFont: "bold 18px Arial",
+  headerText: "Inventory [X]",
+};
+
+const DRAG_START_THRESHOLD = 12;
+const DRAG_START_THRESHOLD_SQUARED = DRAG_START_THRESHOLD * DRAG_START_THRESHOLD;
+
+type PanelMetrics = {
+  panelX: number;
+  panelY: number;
+  panelWidth: number;
+  panelHeight: number;
+  slotsLeft: number;
+  slotsTop: number;
+  slotSize: number;
+  slotsGap: number;
+  columns: number;
+  rows: number;
+};
+
+type DragState = {
+  slotIndex: number; // Actual inventory index (10-25)
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+  isDragging: boolean;
+  targetSlotIndex: number | null;
+};
+
+export class InventoryPanelUI implements Renderable {
+  private assetManager: AssetManager;
+  private inputManager: InputManager;
+  private getInventory: () => InventoryItem[];
+  private sendSwapItems: (fromSlotIndex: number, toSlotIndex: number) => void;
+  private isOpen: boolean = false;
+  private hoveredSlot: number | null = null;
+  private mouseX: number = 0;
+  private mouseY: number = 0;
+  private dragState: DragState | null = null;
+  private lastCanvasWidth: number = 0;
+  private lastCanvasHeight: number = 0;
+
+  // External drag state (from hotbar)
+  private externalDragSlot: number | null = null;
+  private externalDragX: number = 0;
+  private externalDragY: number = 0;
+
+  constructor(
+    assetManager: AssetManager,
+    inputManager: InputManager,
+    getInventory: () => InventoryItem[],
+    sendSwapItems: (fromSlotIndex: number, toSlotIndex: number) => void
+  ) {
+    this.assetManager = assetManager;
+    this.inputManager = inputManager;
+    this.getInventory = getInventory;
+    this.sendSwapItems = sendSwapItems;
+  }
+
+  public toggle(): void {
+    this.isOpen = !this.isOpen;
+    if (!this.isOpen) {
+      this.dragState = null;
+      this.hoveredSlot = null;
+    }
+  }
+
+  public open(): void {
+    this.isOpen = true;
+  }
+
+  public close(): void {
+    this.isOpen = false;
+    this.dragState = null;
+    this.hoveredSlot = null;
+  }
+
+  public isVisible(): boolean {
+    return this.isOpen;
+  }
+
+  public render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
+    if (!this.isOpen) return;
+
+    const { width: canvasWidth, height: canvasHeight } = ctx.canvas;
+    const hudScale = calculateHudScale(canvasWidth, canvasHeight);
+    const settings = INVENTORY_PANEL_SETTINGS;
+
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    // Scale dimensions
+    const scaledSlotSize = settings.slotSize * hudScale;
+    const scaledSlotsGap = settings.slotsGap * hudScale;
+    const scaledPadding = {
+      top: settings.padding.top * hudScale,
+      bottom: settings.padding.bottom * hudScale,
+      left: settings.padding.left * hudScale,
+      right: settings.padding.right * hudScale,
+    };
+    const scaledBorderWidth = settings.borderWidth * hudScale;
+    const scaledHeaderHeight = settings.headerHeight * hudScale;
+
+    // Calculate panel dimensions
+    const panelWidth =
+      settings.columns * scaledSlotSize +
+      (settings.columns - 1) * scaledSlotsGap +
+      scaledPadding.left +
+      scaledPadding.right;
+    const panelHeight =
+      settings.rows * scaledSlotSize +
+      (settings.rows - 1) * scaledSlotsGap +
+      scaledPadding.top +
+      scaledPadding.bottom +
+      scaledHeaderHeight;
+
+    // Center panel on screen
+    const panelX = (canvasWidth - panelWidth) / 2;
+    const panelY = (canvasHeight - panelHeight) / 2 - 50 * hudScale; // Slightly above center
+
+    // Draw panel background
+    ctx.fillStyle = settings.containerBackground;
+    ctx.fillRect(panelX, panelY, panelWidth, panelHeight);
+
+    // Draw panel border
+    ctx.strokeStyle = settings.borderColor;
+    ctx.lineWidth = scaledBorderWidth;
+    ctx.strokeRect(panelX, panelY, panelWidth, panelHeight);
+
+    // Draw header
+    const headerFontSize = 18 * hudScale;
+    ctx.font = `bold ${headerFontSize}px Arial`;
+    ctx.textAlign = "center";
+    ctx.fillStyle = "white";
+    ctx.fillText(
+      settings.headerText,
+      panelX + panelWidth / 2,
+      panelY + scaledHeaderHeight / 2 + headerFontSize / 3
+    );
+
+    // Draw header separator
+    ctx.strokeStyle = settings.borderColor;
+    ctx.lineWidth = 1 * hudScale;
+    ctx.beginPath();
+    ctx.moveTo(panelX, panelY + scaledHeaderHeight);
+    ctx.lineTo(panelX + panelWidth, panelY + scaledHeaderHeight);
+    ctx.stroke();
+
+    const slotsLeft = panelX + scaledPadding.left;
+    const slotsTop = panelY + scaledHeaderHeight + scaledPadding.top;
+    const items = this.getInventory();
+    const dragState = this.dragState;
+    const isDragging = !!dragState?.isDragging;
+    const draggingSlotIndex = isDragging ? dragState?.slotIndex ?? null : null;
+    const targetSlotIndex = isDragging ? dragState?.targetSlotIndex ?? null : null;
+
+    // Extended inventory starts at slot index 10
+    const startSlotIndex = getConfig().player.HOTBAR_SLOTS;
+
+    for (let row = 0; row < settings.rows; row++) {
+      for (let col = 0; col < settings.columns; col++) {
+        const localIndex = row * settings.columns + col;
+        const slotIndex = startSlotIndex + localIndex; // Actual inventory index
+
+        const slotLeft = slotsLeft + col * (scaledSlotSize + scaledSlotsGap);
+        const slotTop = slotsTop + row * (scaledSlotSize + scaledSlotsGap);
+        const slotBottom = slotTop + scaledSlotSize;
+        const slotRight = slotLeft + scaledSlotSize;
+
+        const isDraggingSlot = isDragging && draggingSlotIndex === slotIndex;
+        const isTargetSlot =
+          isDragging && targetSlotIndex === slotIndex && targetSlotIndex !== draggingSlotIndex;
+        const isHovered = this.hoveredSlot === slotIndex && !isDragging;
+
+        // Draw slot background
+        ctx.fillStyle = settings.slotBackground;
+        ctx.fillRect(slotLeft, slotTop, scaledSlotSize, scaledSlotSize);
+
+        if (isDraggingSlot) {
+          ctx.fillStyle = "rgba(255, 255, 255, 0.1)";
+          ctx.fillRect(slotLeft, slotTop, scaledSlotSize, scaledSlotSize);
+        }
+
+        // Draw slot border
+        if (isTargetSlot) {
+          ctx.strokeStyle = "rgba(100, 200, 255, 0.9)";
+          ctx.lineWidth = scaledBorderWidth * 1.5;
+          ctx.strokeRect(slotLeft, slotTop, scaledSlotSize, scaledSlotSize);
+        } else if (isHovered) {
+          ctx.strokeStyle = settings.activeBorderColor;
+          ctx.lineWidth = scaledBorderWidth * 1.5;
+          ctx.strokeRect(slotLeft, slotTop, scaledSlotSize, scaledSlotSize);
+        } else {
+          ctx.strokeStyle = settings.borderColor;
+          ctx.lineWidth = scaledBorderWidth;
+          ctx.strokeRect(slotLeft, slotTop, scaledSlotSize, scaledSlotSize);
+        }
+
+        const inventoryItem = items[slotIndex];
+        const image = inventoryItem && this.assetManager.get(getItemAssetKey(inventoryItem));
+
+        if (image) {
+          const imagePadding = 8 * hudScale;
+          if (isDraggingSlot) {
+            ctx.save();
+            ctx.globalAlpha = 0.35;
+            ctx.drawImage(
+              image,
+              slotLeft + imagePadding,
+              slotTop + imagePadding,
+              scaledSlotSize - imagePadding * 2,
+              scaledSlotSize - imagePadding * 2
+            );
+            ctx.restore();
+          } else {
+            ctx.drawImage(
+              image,
+              slotLeft + imagePadding,
+              slotTop + imagePadding,
+              scaledSlotSize - imagePadding * 2,
+              scaledSlotSize - imagePadding * 2
+            );
+          }
+        }
+
+        // Draw item count
+        const slotFontSize = 20 * hudScale;
+        if (inventoryItem?.state?.count) {
+          ctx.font = `bold ${slotFontSize}px Arial`;
+          ctx.textAlign = "right";
+          ctx.fillStyle = "white";
+          ctx.strokeStyle = "rgba(0, 0, 0, 0.8)";
+          ctx.lineWidth = 3 * hudScale;
+          const countX = slotRight - 6 * hudScale;
+          const countY = slotBottom - 6 * hudScale;
+          ctx.strokeText(`${inventoryItem.state.count}`, countX, countY);
+          ctx.fillText(`${inventoryItem.state.count}`, countX, countY);
+        }
+
+        // Draw ammo count for weapons
+        if (isWeapon(inventoryItem?.itemType)) {
+          const ammoType = getWeaponAmmoType(inventoryItem.itemType);
+          if (ammoType) {
+            const ammoItem = this.getInventory().find(
+              (item) => item?.itemType === getWeaponAmmoType(inventoryItem.itemType)
+            );
+            const ammoCount = ammoItem?.state?.count ?? 0;
+            const ammoFontSize = slotFontSize * 0.7;
+            ctx.font = `bold ${ammoFontSize}px Arial`;
+            ctx.textAlign = "right";
+            ctx.fillStyle = ammoCount > 0 ? "rgba(255, 255, 0, 1)" : "rgba(255, 100, 100, 1)";
+            ctx.strokeStyle = "rgba(0, 0, 0, 0.8)";
+            ctx.lineWidth = 2 * hudScale;
+            const ammoX = slotRight - 6 * hudScale;
+            const ammoY = slotBottom - 6 * hudScale;
+            ctx.strokeText(`${ammoCount}`, ammoX, ammoY);
+            ctx.fillText(`${ammoCount}`, ammoX, ammoY);
+          }
+        }
+      }
+    }
+
+    this.renderDragPreview(ctx, scaledSlotSize);
+    this.renderTooltip(ctx, scaledSlotSize);
+    ctx.restore();
+  }
+
+  private renderTooltip(ctx: CanvasRenderingContext2D, scaledSlotSize: number): void {
+    if (this.dragState?.isDragging || this.hoveredSlot === null) return;
+
+    const items = this.getInventory();
+    const hoveredItem = items[this.hoveredSlot];
+    if (!hoveredItem) return;
+
+    const { width: canvasWidth, height: canvasHeight } = ctx.canvas;
+    const hudScale = calculateHudScale(canvasWidth, canvasHeight);
+    const metrics = this.getPanelMetrics(canvasWidth, canvasHeight);
+    if (!metrics) return;
+
+    const startSlotIndex = getConfig().player.HOTBAR_SLOTS;
+    const localIndex = this.hoveredSlot - startSlotIndex;
+    const row = Math.floor(localIndex / metrics.columns);
+    const col = localIndex % metrics.columns;
+
+    const slotLeft = metrics.slotsLeft + col * (metrics.slotSize + metrics.slotsGap);
+    const slotTop = metrics.slotsTop + row * (metrics.slotSize + metrics.slotsGap);
+    const slotCenterX = slotLeft + metrics.slotSize / 2;
+
+    const itemName = formatDisplayName(hoveredItem.itemType);
+    const tooltipFontSize = 18 * hudScale;
+    ctx.font = `bold ${tooltipFontSize}px Arial`;
+    ctx.textAlign = "center";
+    const textMetrics = ctx.measureText(itemName);
+    const textWidth = textMetrics.width;
+
+    const tooltipPadding = 8 * hudScale;
+    const tooltipWidth = textWidth + tooltipPadding * 2;
+    const tooltipHeight = tooltipFontSize + tooltipPadding * 2;
+    const tooltipX = slotCenterX - tooltipWidth / 2;
+    const tooltipY = slotTop - tooltipHeight - 8 * hudScale;
+
+    ctx.fillStyle = "rgba(0, 0, 0, 0.9)";
+    ctx.fillRect(tooltipX, tooltipY, tooltipWidth, tooltipHeight);
+
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.5)";
+    ctx.lineWidth = 2 * hudScale;
+    ctx.strokeRect(tooltipX, tooltipY, tooltipWidth, tooltipHeight);
+
+    ctx.fillStyle = "white";
+    ctx.strokeStyle = "rgba(0, 0, 0, 0.8)";
+    ctx.lineWidth = 3 * hudScale;
+    const textY = tooltipY + tooltipPadding + tooltipFontSize - 4 * hudScale;
+    ctx.strokeText(itemName, slotCenterX, textY);
+    ctx.fillText(itemName, slotCenterX, textY);
+  }
+
+  private renderDragPreview(ctx: CanvasRenderingContext2D, scaledSlotSize: number): void {
+    if (!this.dragState?.isDragging) return;
+
+    const items = this.getInventory();
+    const draggedItem = items[this.dragState.slotIndex];
+    if (!draggedItem) return;
+
+    const image = this.assetManager.get(getItemAssetKey(draggedItem));
+    if (!image) return;
+
+    const previewSize = scaledSlotSize * 0.85;
+    const drawX = this.dragState.currentX - previewSize / 2;
+    const drawY = this.dragState.currentY - previewSize / 2;
+
+    ctx.save();
+    ctx.globalAlpha = 0.9;
+    ctx.drawImage(image, drawX, drawY, previewSize, previewSize);
+    ctx.restore();
+  }
+
+  public getZIndex(): number {
+    return Z_INDEX.UI + 10; // Above hotbar
+  }
+
+  public isHovering(): boolean {
+    return this.isOpen && this.hoveredSlot !== null;
+  }
+
+  public updateMousePosition(
+    x: number,
+    y: number,
+    canvasWidth: number,
+    canvasHeight: number
+  ): void {
+    if (!this.isOpen) return;
+
+    this.mouseX = x;
+    this.mouseY = y;
+    this.lastCanvasWidth = canvasWidth;
+    this.lastCanvasHeight = canvasHeight;
+
+    if (this.dragState) {
+      this.dragState.currentX = x;
+      this.dragState.currentY = y;
+      if (this.dragState.isDragging) {
+        const metrics = this.getPanelMetrics(canvasWidth, canvasHeight);
+        if (metrics) {
+          this.dragState.targetSlotIndex = this.getSlotIndexAtPosition(x, y, metrics);
+        }
+        this.hoveredSlot = null;
+        return;
+      }
+    }
+
+    const metrics = this.getPanelMetrics(canvasWidth, canvasHeight);
+    if (!metrics) {
+      this.hoveredSlot = null;
+      return;
+    }
+
+    this.hoveredSlot = this.getSlotIndexAtPosition(x, y, metrics);
+  }
+
+  public handleClick(x: number, y: number, canvasWidth: number, canvasHeight: number, shiftHeld: boolean = false): boolean {
+    if (!this.isOpen) return false;
+
+    this.lastCanvasWidth = canvasWidth;
+    this.lastCanvasHeight = canvasHeight;
+
+    const metrics = this.getPanelMetrics(canvasWidth, canvasHeight);
+    if (!metrics) {
+      this.dragState = null;
+      return false;
+    }
+
+    // Check if click is inside panel
+    if (!this.isPointInsidePanel(x, y, metrics)) {
+      this.dragState = null;
+      return false;
+    }
+
+    const slotIndex = this.getSlotIndexAtPosition(x, y, metrics);
+    if (slotIndex === null) {
+      this.dragState = null;
+      return true; // Clicked inside panel but not on slot
+    }
+
+    // Shift+click: quick move to hotbar
+    if (shiftHeld) {
+      const items = this.getInventory();
+      const item = items[slotIndex];
+      if (item) {
+        const targetSlot = this.findTargetSlotInHotbar(slotIndex, items);
+        if (targetSlot !== null) {
+          this.sendSwapItems(slotIndex, targetSlot);
+          return true;
+        }
+      }
+    }
+
+    this.prepareDragState(slotIndex, x, y);
+    return true;
+  }
+
+  // Find target slot in hotbar for quick move
+  private findTargetSlotInHotbar(fromSlot: number, items: InventoryItem[]): number | null {
+    const hotbarSlots = getConfig().player.HOTBAR_SLOTS;
+    
+    // Preferred slot: corresponding position in hotbar (slot 10 -> 0, slot 11 -> 1, etc.)
+    const preferredSlot = fromSlot - hotbarSlots;
+    
+    // If preferred slot is valid and empty, use it
+    if (preferredSlot >= 0 && preferredSlot < hotbarSlots && !items[preferredSlot]) {
+      return preferredSlot;
+    }
+    
+    // Otherwise find first empty slot in hotbar range
+    for (let i = 0; i < hotbarSlots; i++) {
+      if (!items[i]) {
+        return i;
+      }
+    }
+    
+    // No empty slot, swap with preferred slot anyway (if valid)
+    if (preferredSlot >= 0 && preferredSlot < hotbarSlots) {
+      return preferredSlot;
+    }
+    
+    // Fallback to first hotbar slot
+    return 0;
+  }
+
+  public handleMouseMove(x: number, y: number, canvasWidth?: number, canvasHeight?: number): void {
+    if (!this.isOpen) return;
+
+    if (canvasWidth !== undefined && canvasHeight !== undefined) {
+      this.lastCanvasWidth = canvasWidth;
+      this.lastCanvasHeight = canvasHeight;
+    }
+
+    if (!this.dragState) return;
+
+    this.dragState.currentX = x;
+    this.dragState.currentY = y;
+
+    if (!this.dragState.isDragging) {
+      const dx = x - this.dragState.startX;
+      const dy = y - this.dragState.startY;
+      if (dx * dx + dy * dy >= DRAG_START_THRESHOLD_SQUARED) {
+        this.dragState.isDragging = true;
+        this.hoveredSlot = null;
+      }
+    }
+
+    if (this.dragState.isDragging) {
+      const metrics = this.getPanelMetrics(this.lastCanvasWidth, this.lastCanvasHeight);
+      if (metrics) {
+        this.dragState.targetSlotIndex = this.getSlotIndexAtPosition(x, y, metrics);
+      }
+    }
+  }
+
+  public handleMouseUp(x: number, y: number, canvasWidth?: number, canvasHeight?: number): void {
+    if (!this.isOpen) return;
+
+    if (canvasWidth !== undefined && canvasHeight !== undefined) {
+      this.lastCanvasWidth = canvasWidth;
+      this.lastCanvasHeight = canvasHeight;
+    }
+
+    const dragState = this.dragState;
+    this.dragState = null;
+
+    if (!dragState || !dragState.isDragging) return;
+
+    const metrics = this.getPanelMetrics(this.lastCanvasWidth, this.lastCanvasHeight);
+    if (!metrics) return;
+
+    const targetSlotIndex = this.getSlotIndexAtPosition(x, y, metrics);
+    if (targetSlotIndex !== null && targetSlotIndex !== dragState.slotIndex) {
+      this.sendSwapItems(dragState.slotIndex, targetSlotIndex);
+    }
+  }
+
+  // Handle external drag from hotbar ending on this panel
+  public handleExternalDrop(fromSlotIndex: number, x: number, y: number): boolean {
+    if (!this.isOpen) return false;
+
+    const metrics = this.getPanelMetrics(this.lastCanvasWidth, this.lastCanvasHeight);
+    if (!metrics) return false;
+
+    if (!this.isPointInsidePanel(x, y, metrics)) return false;
+
+    const targetSlotIndex = this.getSlotIndexAtPosition(x, y, metrics);
+    if (targetSlotIndex !== null) {
+      this.sendSwapItems(fromSlotIndex, targetSlotIndex);
+      return true;
+    }
+
+    return false;
+  }
+
+  // Get target slot index for external drag preview
+  public getTargetSlotForExternalDrag(x: number, y: number): number | null {
+    if (!this.isOpen) return null;
+
+    const metrics = this.getPanelMetrics(this.lastCanvasWidth, this.lastCanvasHeight);
+    if (!metrics) return null;
+
+    if (!this.isPointInsidePanel(x, y, metrics)) return null;
+
+    return this.getSlotIndexAtPosition(x, y, metrics);
+  }
+
+  public setExternalDrag(slotIndex: number | null, x: number, y: number): void {
+    this.externalDragSlot = slotIndex;
+    this.externalDragX = x;
+    this.externalDragY = y;
+  }
+
+  public isDragging(): boolean {
+    return this.dragState?.isDragging ?? false;
+  }
+
+  public getDragState(): DragState | null {
+    return this.dragState;
+  }
+
+  private prepareDragState(slotIndex: number, startX: number, startY: number): void {
+    const items = this.getInventory();
+    const item = items[slotIndex];
+    if (!item) {
+      this.dragState = null;
+      return;
+    }
+
+    this.dragState = {
+      slotIndex,
+      startX,
+      startY,
+      currentX: startX,
+      currentY: startY,
+      isDragging: false,
+      targetSlotIndex: null,
+    };
+  }
+
+  private getPanelMetrics(canvasWidth?: number, canvasHeight?: number): PanelMetrics | null {
+    const width = canvasWidth ?? this.lastCanvasWidth;
+    const height = canvasHeight ?? this.lastCanvasHeight;
+
+    if (!width || !height) return null;
+
+    const hudScale = calculateHudScale(width, height);
+    const settings = INVENTORY_PANEL_SETTINGS;
+
+    const scaledSlotSize = settings.slotSize * hudScale;
+    const scaledSlotsGap = settings.slotsGap * hudScale;
+    const scaledPadding = {
+      top: settings.padding.top * hudScale,
+      bottom: settings.padding.bottom * hudScale,
+      left: settings.padding.left * hudScale,
+      right: settings.padding.right * hudScale,
+    };
+    const scaledHeaderHeight = settings.headerHeight * hudScale;
+
+    const panelWidth =
+      settings.columns * scaledSlotSize +
+      (settings.columns - 1) * scaledSlotsGap +
+      scaledPadding.left +
+      scaledPadding.right;
+    const panelHeight =
+      settings.rows * scaledSlotSize +
+      (settings.rows - 1) * scaledSlotsGap +
+      scaledPadding.top +
+      scaledPadding.bottom +
+      scaledHeaderHeight;
+
+    const panelX = (width - panelWidth) / 2;
+    const panelY = (height - panelHeight) / 2 - 50 * hudScale;
+
+    return {
+      panelX,
+      panelY,
+      panelWidth,
+      panelHeight,
+      slotsLeft: panelX + scaledPadding.left,
+      slotsTop: panelY + scaledHeaderHeight + scaledPadding.top,
+      slotSize: scaledSlotSize,
+      slotsGap: scaledSlotsGap,
+      columns: settings.columns,
+      rows: settings.rows,
+    };
+  }
+
+  private getSlotIndexAtPosition(x: number, y: number, metrics: PanelMetrics): number | null {
+    const startSlotIndex = getConfig().player.HOTBAR_SLOTS;
+
+    for (let row = 0; row < metrics.rows; row++) {
+      for (let col = 0; col < metrics.columns; col++) {
+        const slotLeft = metrics.slotsLeft + col * (metrics.slotSize + metrics.slotsGap);
+        const slotTop = metrics.slotsTop + row * (metrics.slotSize + metrics.slotsGap);
+        const slotRight = slotLeft + metrics.slotSize;
+        const slotBottom = slotTop + metrics.slotSize;
+
+        if (x >= slotLeft && x <= slotRight && y >= slotTop && y <= slotBottom) {
+          return startSlotIndex + row * metrics.columns + col;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private isPointInsidePanel(x: number, y: number, metrics: PanelMetrics): boolean {
+    return (
+      x >= metrics.panelX &&
+      x <= metrics.panelX + metrics.panelWidth &&
+      y >= metrics.panelY &&
+      y <= metrics.panelY + metrics.panelHeight
+    );
+  }
+}

--- a/packages/game-client/src/ui/panels/hearts-panel.ts
+++ b/packages/game-client/src/ui/panels/hearts-panel.ts
@@ -33,7 +33,7 @@ export class HeartsPanel extends Panel {
     const { width: canvasWidth, height: canvasHeight } = ctx.canvas;
     const hudScale = calculateHudScale(canvasWidth, canvasHeight);
     const settings = this.heartSettings.inventorySettings;
-    const slotsNumber = getConfig().player.MAX_INVENTORY_SLOTS;
+    const slotsNumber = getConfig().player.HOTBAR_SLOTS;
 
     this.resetTransform(ctx);
 

--- a/packages/game-client/src/ui/panels/stamina-panel.ts
+++ b/packages/game-client/src/ui/panels/stamina-panel.ts
@@ -37,7 +37,7 @@ export class StaminaPanel extends Panel {
     const { width: canvasWidth, height: canvasHeight } = ctx.canvas;
     const hudScale = calculateHudScale(canvasWidth, canvasHeight);
     const settings = this.staminaSettings.inventorySettings;
-    const slotsNumber = getConfig().player.MAX_INVENTORY_SLOTS;
+    const slotsNumber = getConfig().player.HOTBAR_SLOTS;
 
     this.resetTransform(ctx);
 

--- a/packages/game-shared/src/config/keybindings-config.ts
+++ b/packages/game-shared/src/config/keybindings-config.ts
@@ -19,6 +19,7 @@ export const keybindingsConfig = {
   PLAYER_LIST: "tab",
   WEAPONS_HUD: "f",
   QUICK_SWITCH: "q",
+  TOGGLE_INVENTORY: "x",
 } as const;
 
 export type KeybindingsConfig = typeof keybindingsConfig;

--- a/packages/game-shared/src/config/player-config.ts
+++ b/packages/game-shared/src/config/player-config.ts
@@ -12,9 +12,19 @@ export const playerConfig = {
   MAX_PLAYER_HEALTH: 10,
 
   /**
-   * Maximum inventory slots
+   * Maximum inventory slots (10 hotbar + 16 extended inventory)
    */
-  MAX_INVENTORY_SLOTS: 10,
+  MAX_INVENTORY_SLOTS: 26,
+
+  /**
+   * Number of hotbar slots (visible at bottom of screen)
+   */
+  HOTBAR_SLOTS: 10,
+
+  /**
+   * Number of extended inventory slots (8 columns x 2 rows)
+   */
+  EXTENDED_INVENTORY_SLOTS: 16,
 
   /**
    * Maximum distance for interaction with objects (in pixels)


### PR DESCRIPTION
Added a new inventory panel that opens when you press X. It has 16 extra slots arranged in two rows of 8, giving players more space to store items beyond the main hotbar.

You can drag items between the hotbar and the inventory panel, and shift-clicking will quickly move items back and forth. When shift-clicking, items try to go to the corresponding slot first, but if that slot is taken they just go to the next available one.

The hotbar still shows 10 slots at the bottom like before, and the hearts and stamina bars stay aligned to its edges.