### PR TITLE
Add RPG-style NPC dialogue panel and NPC collision

### DIFF
--- a/packages/game-client/src/client.ts
+++ b/packages/game-client/src/client.ts
@@ -281,6 +281,10 @@ export class GameClient {
               openEnt.getExt(ClientPositionable).getCenterPosition(),
             );
             if (d <= maxInteract) {
+              if (!this.hud.isDialogueLineFullyRevealed(this.gameState)) {
+                this.hud.completeDialogueLine(this.gameState);
+                return;
+              }
               this.advanceNpcDialogue();
               return;
             }

--- a/packages/game-client/src/entities/environment/dialogue-survivor-npc.ts
+++ b/packages/game-client/src/entities/environment/dialogue-survivor-npc.ts
@@ -138,6 +138,10 @@ export class DialogueSurvivorNpcClient extends ClientEntity implements Renderabl
       return;
     }
 
+    if (gameState.openDialogueNpcId === this.getId()) {
+      return;
+    }
+
     const total = this.getTotalDialogueLineCount(gameState);
     const onLast =
       gameState.openDialogueNpcId === this.getId() &&

--- a/packages/game-client/src/entities/environment/message-decal.ts
+++ b/packages/game-client/src/entities/environment/message-decal.ts
@@ -79,6 +79,10 @@ export class MessageDecalClient extends ClientEntity implements Renderable {
       return;
     }
 
+    if (gameState.openDialogueNpcId === this.getId()) {
+      return;
+    }
+
     const total = this.getLineCount();
     const onLast =
       gameState.openDialogueNpcId === this.getId() &&

--- a/packages/game-client/src/renderer.ts
+++ b/packages/game-client/src/renderer.ts
@@ -22,8 +22,6 @@ import { getPlayer } from "./util/get-player";
 import { distance } from "@shared/util/physics";
 import { isAutoPickupItem } from "./util/auto-pickup";
 import { resizeCanvasToWindow } from "./util/canvas-size";
-import { renderOpenDialogueSpeechBubble } from "./entities/environment/dialogue-survivor-npc";
-import { renderOpenMessageDecalSpeechBubble } from "./entities/environment/message-decal";
 
 export class Renderer {
   private ctx: CanvasRenderingContext2D;
@@ -273,10 +271,6 @@ export class Renderer {
 
     // Apply zombie "undead view" overlay if player is a zombie
     this.mapManager.renderZombieOverlay(this.ctx);
-
-    // Dialogue speech bubble (world space) after darkness/zombie overlays so text stays readable
-    renderOpenDialogueSpeechBubble(this.ctx, this.gameState);
-    renderOpenMessageDecalSpeechBubble(this.ctx, this.gameState);
 
     // Render UI without transforms
     perfTimer.start("renderUI");

--- a/packages/game-client/src/ui/dialogue-panel.ts
+++ b/packages/game-client/src/ui/dialogue-panel.ts
@@ -1,0 +1,342 @@
+import { DialogueSurvivorNpcClient } from "@/entities/environment/dialogue-survivor-npc";
+import { MessageDecalClient } from "@/entities/environment/message-decal";
+import { AssetManager } from "@/managers/asset";
+import { GameState, getEntityById } from "@/state";
+import { calculateHudScale } from "@/util/hud-scale";
+import { getConfig } from "@shared/config";
+import { Direction } from "@shared/util/direction";
+
+const TYPEWRITER_MS_PER_CHAR = 24;
+const PANEL_OPEN_SPEED = 7;
+const PANEL_CLOSE_SPEED = 10;
+
+type DialogueSnapshot = {
+  entityId: number;
+  lineIndex: number;
+  totalLines: number;
+  line: string;
+  speaker: string;
+  footer: string;
+  showPortrait: boolean;
+};
+
+function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let line = "";
+
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (ctx.measureText(candidate).width <= maxWidth) {
+      line = candidate;
+      continue;
+    }
+
+    if (line) {
+      lines.push(line);
+    }
+    line = word;
+  }
+
+  if (line) {
+    lines.push(line);
+  }
+
+  return lines.length > 0 ? lines : [""];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function easeOutCubic(value: number): number {
+  return 1 - Math.pow(1 - value, 3);
+}
+
+export class DialoguePanel {
+  private visibilityProgress = 0;
+  private lastAnimationAt = 0;
+  private activeLineKey: string | null = null;
+  private revealStartedAt = 0;
+  private revealInstantly = false;
+  private lastSnapshot: DialogueSnapshot | null = null;
+
+  constructor(private assetManager: AssetManager) {}
+
+  public getOcclusionProgress(): number {
+    return this.visibilityProgress;
+  }
+
+  public isCurrentLineFullyRevealed(gameState: GameState): boolean {
+    const now = performance.now();
+    const snapshot = this.resolveSnapshot(gameState);
+    this.syncSnapshot(snapshot, now);
+
+    if (!snapshot) {
+      return true;
+    }
+
+    return this.getVisibleCharacterCount(snapshot, now) >= snapshot.line.length;
+  }
+
+  public completeCurrentLine(gameState: GameState): boolean {
+    const now = performance.now();
+    const snapshot = this.resolveSnapshot(gameState);
+    this.syncSnapshot(snapshot, now);
+
+    if (!snapshot) {
+      return false;
+    }
+
+    if (this.getVisibleCharacterCount(snapshot, now) >= snapshot.line.length) {
+      return false;
+    }
+
+    this.revealInstantly = true;
+    return true;
+  }
+
+  public render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
+    const now = performance.now();
+    const snapshot = this.resolveSnapshot(gameState);
+    this.syncSnapshot(snapshot, now);
+    this.stepVisibility(snapshot !== null, now);
+
+    const renderSnapshot = snapshot ?? this.lastSnapshot;
+    if (!renderSnapshot || this.visibilityProgress <= 0.001) {
+      if (!snapshot && this.visibilityProgress <= 0.001) {
+        this.lastSnapshot = null;
+      }
+      return;
+    }
+
+    const { width, height } = ctx.canvas;
+    const scale = calculateHudScale(width, height);
+    const easedProgress = easeOutCubic(this.visibilityProgress);
+    const sideMargin = Math.max(18, Math.round(26 * scale));
+    const bottomMargin = Math.max(14, Math.round(18 * scale));
+    const panelWidth = Math.min(width - sideMargin * 2, Math.round(1080 * scale));
+    const panelHeight = Math.max(118, Math.round(170 * scale));
+    const hiddenOffset = Math.round(170 * scale);
+    const x = Math.round((width - panelWidth) / 2);
+    const y =
+      height - panelHeight - bottomMargin + Math.round((1 - easedProgress) * hiddenOffset);
+    const innerPad = Math.max(12, Math.round(18 * scale));
+    const accentHeight = Math.max(4, Math.round(5 * scale));
+    const portraitBoxSize = renderSnapshot.showPortrait ? Math.max(72, Math.round(98 * scale)) : 0;
+    const portraitGap = renderSnapshot.showPortrait ? Math.max(10, Math.round(14 * scale)) : 0;
+    const headerHeight = Math.max(26, Math.round(30 * scale));
+    const footerHeight = Math.max(22, Math.round(24 * scale));
+    const panelBottomFadeHeight = panelHeight + Math.round(40 * scale);
+
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.imageSmoothingEnabled = false;
+
+    const backgroundFade = ctx.createLinearGradient(0, height - panelBottomFadeHeight, 0, height);
+    backgroundFade.addColorStop(0, "rgba(0, 0, 0, 0)");
+    backgroundFade.addColorStop(1, `rgba(0, 0, 0, ${0.4 * easedProgress})`);
+    ctx.fillStyle = backgroundFade;
+    ctx.fillRect(0, height - panelBottomFadeHeight, width, panelBottomFadeHeight);
+
+    const outerGradient = ctx.createLinearGradient(x, y, x, y + panelHeight);
+    outerGradient.addColorStop(0, "rgba(16, 18, 31, 0.98)");
+    outerGradient.addColorStop(1, "rgba(6, 8, 16, 0.95)");
+    ctx.fillStyle = outerGradient;
+    ctx.fillRect(x, y, panelWidth, panelHeight);
+
+    ctx.strokeStyle = "rgba(255, 234, 182, 0.8)";
+    ctx.lineWidth = Math.max(2, Math.round(2 * scale));
+    ctx.strokeRect(x, y, panelWidth, panelHeight);
+
+    ctx.fillStyle = "rgba(240, 198, 108, 0.96)";
+    ctx.fillRect(x, y, panelWidth, accentHeight);
+
+    const contentTop = y + innerPad;
+    const portraitX = x + innerPad;
+    const portraitY = contentTop + headerHeight;
+    const bodyX = portraitX + portraitBoxSize + portraitGap;
+    const bodyWidth = panelWidth - (bodyX - x) - innerPad;
+    const bodyTop = contentTop + headerHeight;
+    const bodyBottom = y + panelHeight - innerPad - footerHeight;
+    const lineCounter = `${renderSnapshot.lineIndex + 1}/${renderSnapshot.totalLines}`;
+    const visibleChars = this.getVisibleCharacterCount(renderSnapshot, now);
+    const isFullyRevealed = visibleChars >= renderSnapshot.line.length;
+    const visibleText = isFullyRevealed
+      ? renderSnapshot.line
+      : `${renderSnapshot.line.slice(0, visibleChars)}|`;
+    const interactionKey = String(getConfig().keybindings.INTERACT || "E").toUpperCase();
+
+    ctx.font = `bold ${Math.max(14, Math.round(18 * scale))}px Georgia`;
+    ctx.textBaseline = "top";
+    ctx.textAlign = "left";
+    ctx.fillStyle = "#f8f2dc";
+    ctx.fillText(renderSnapshot.speaker, bodyX, contentTop);
+
+    ctx.textAlign = "right";
+    ctx.fillStyle = "rgba(255, 215, 132, 0.88)";
+    ctx.font = `bold ${Math.max(11, Math.round(13 * scale))}px Arial`;
+    ctx.fillText(lineCounter, x + panelWidth - innerPad, contentTop + Math.round(2 * scale));
+
+    if (renderSnapshot.showPortrait) {
+      ctx.fillStyle = "rgba(29, 35, 53, 0.98)";
+      ctx.fillRect(portraitX, portraitY, portraitBoxSize, portraitBoxSize);
+      ctx.strokeStyle = "rgba(255, 223, 155, 0.78)";
+      ctx.lineWidth = Math.max(2, Math.round(2 * scale));
+      ctx.strokeRect(portraitX, portraitY, portraitBoxSize, portraitBoxSize);
+
+      const portraitInnerPad = Math.max(8, Math.round(10 * scale));
+      const portraitImage = this.assetManager.getWithDirection("survivor" as any, Direction.Down);
+      ctx.drawImage(
+        portraitImage,
+        portraitX + portraitInnerPad,
+        portraitY + portraitInnerPad,
+        portraitBoxSize - portraitInnerPad * 2,
+        portraitBoxSize - portraitInnerPad * 2,
+      );
+
+      ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+      ctx.fillRect(
+        portraitX,
+        portraitY + portraitBoxSize - Math.max(18, Math.round(20 * scale)),
+        portraitBoxSize,
+        Math.max(18, Math.round(20 * scale)),
+      );
+      ctx.fillStyle = "rgba(255, 232, 178, 0.95)";
+      ctx.font = `bold ${Math.max(10, Math.round(11 * scale))}px Arial`;
+      ctx.textAlign = "center";
+      ctx.fillText("NPC", portraitX + portraitBoxSize / 2, portraitY + portraitBoxSize - 16 * scale);
+      ctx.textAlign = "left";
+    }
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(bodyX, bodyTop, bodyWidth, Math.max(10, bodyBottom - bodyTop));
+    ctx.clip();
+
+    ctx.font = `${Math.max(13, Math.round(16 * scale))}px Arial`;
+    ctx.fillStyle = "#f4f7ff";
+    const wrappedLines = wrapText(ctx, visibleText, bodyWidth);
+    const lineHeight = Math.max(18, Math.round(22 * scale));
+    for (let index = 0; index < wrappedLines.length; index++) {
+      const line = wrappedLines[index]!;
+      const lineY = bodyTop + index * lineHeight;
+      if (lineY + lineHeight > bodyBottom) {
+        break;
+      }
+      ctx.fillText(line, bodyX, lineY);
+    }
+    ctx.restore();
+
+    ctx.font = `bold ${Math.max(10, Math.round(12 * scale))}px Arial`;
+    ctx.textAlign = "left";
+    ctx.fillStyle = isFullyRevealed ? "rgba(255, 223, 155, 0.95)" : "rgba(165, 218, 255, 0.95)";
+    ctx.fillText(
+      isFullyRevealed ? renderSnapshot.footer : `${interactionKey} to finish line`,
+      bodyX,
+      y + panelHeight - innerPad - footerHeight + Math.round(4 * scale),
+    );
+
+    ctx.textAlign = "right";
+    ctx.fillStyle = "rgba(140, 154, 188, 0.9)";
+    ctx.fillText(
+      isFullyRevealed ? "RPG dialogue" : "Typing...",
+      x + panelWidth - innerPad,
+      y + panelHeight - innerPad - footerHeight + Math.round(4 * scale),
+    );
+
+    ctx.restore();
+  }
+
+  private resolveSnapshot(gameState: GameState): DialogueSnapshot | null {
+    const id = gameState.openDialogueNpcId;
+    if (id == null) {
+      return null;
+    }
+
+    const entity = getEntityById(gameState, id);
+    if (entity instanceof DialogueSurvivorNpcClient) {
+      const totalLines = Math.max(1, entity.getTotalDialogueLineCount(gameState));
+      const lineIndex = clamp(gameState.dialogueLineIndex, 0, totalLines - 1);
+      const keyName = String(getConfig().keybindings.INTERACT || "E").toUpperCase();
+      return {
+        entityId: id,
+        lineIndex,
+        totalLines,
+        line: entity.getDialogueLineAt(lineIndex, gameState),
+        speaker: entity.displayName?.trim() || "Survivor",
+        footer: lineIndex >= totalLines - 1 ? `${keyName} to close` : `${keyName} to continue`,
+        showPortrait: true,
+      };
+    }
+
+    if (entity instanceof MessageDecalClient) {
+      const totalLines = Math.max(1, entity.getLineCount());
+      const lineIndex = clamp(gameState.dialogueLineIndex, 0, totalLines - 1);
+      const keyName = String(getConfig().keybindings.INTERACT || "E").toUpperCase();
+      return {
+        entityId: id,
+        lineIndex,
+        totalLines,
+        line: entity.getLineAt(lineIndex),
+        speaker: "Notice",
+        footer: lineIndex >= totalLines - 1 ? `${keyName} to close` : `${keyName} to continue`,
+        showPortrait: false,
+      };
+    }
+
+    return null;
+  }
+
+  private syncSnapshot(snapshot: DialogueSnapshot | null, now: number): void {
+    const snapshotKey = snapshot ? `${snapshot.entityId}:${snapshot.lineIndex}:${snapshot.line}` : null;
+
+    if (snapshotKey !== this.activeLineKey) {
+      this.activeLineKey = snapshotKey;
+      this.revealStartedAt = now;
+      this.revealInstantly = false;
+    }
+
+    if (snapshot) {
+      this.lastSnapshot = snapshot;
+    }
+  }
+
+  private stepVisibility(isOpen: boolean, now: number): void {
+    const dtSeconds =
+      this.lastAnimationAt > 0 ? Math.min(0.05, (now - this.lastAnimationAt) / 1000) : 1 / 60;
+    this.lastAnimationAt = now;
+
+    const target = isOpen ? 1 : 0;
+    const speed = isOpen ? PANEL_OPEN_SPEED : PANEL_CLOSE_SPEED;
+    const step = dtSeconds * speed;
+
+    if (this.visibilityProgress < target) {
+      this.visibilityProgress = Math.min(target, this.visibilityProgress + step);
+    } else if (this.visibilityProgress > target) {
+      this.visibilityProgress = Math.max(target, this.visibilityProgress - step);
+    }
+
+    if (!isOpen && this.visibilityProgress <= 0.001) {
+      this.lastSnapshot = null;
+      this.activeLineKey = null;
+      this.revealInstantly = false;
+    }
+  }
+
+  private getVisibleCharacterCount(snapshot: DialogueSnapshot, now: number): number {
+    if (!snapshot.line) {
+      return 0;
+    }
+
+    if (this.revealInstantly) {
+      return snapshot.line.length;
+    }
+
+    return clamp(
+      Math.floor((now - this.revealStartedAt) / TYPEWRITER_MS_PER_CHAR),
+      0,
+      snapshot.line.length,
+    );
+  }
+}

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -28,6 +28,7 @@ import { ClientInventory } from "@/extensions/inventory";
 import { renderRadialProgressIndicator } from "@/util/radial-progress-indicator";
 import { getMinimapHudLayout } from "./minimap-hud-group-layout";
 import { QuestJournalPanel } from "./quest-journal-panel";
+import { DialoguePanel } from "./dialogue-panel";
 
 const HUD_SETTINGS = {
   GameMessages: {
@@ -120,6 +121,7 @@ export class Hud {
   private mouseY: number = 0;
   private canvasHeight: number = 0;
   private questJournalPanel: QuestJournalPanel;
+  private dialoguePanel: DialoguePanel;
 
   constructor(
     mapManager: MapManager,
@@ -144,6 +146,7 @@ export class Hud {
     this.getMyPlayer = getMyPlayer;
     this.chatWidget = new ChatWidget();
     this.questJournalPanel = new QuestJournalPanel();
+    this.dialoguePanel = new DialoguePanel(this.assetManager);
 
     // Create getInventory function for HUD that uses currentGameState
     const getInventory = (): (InventoryItem | null)[] => {
@@ -370,6 +373,14 @@ export class Hud {
     this.fpsPanel.setText(`${fps} FPS`);
   }
 
+  public isDialogueLineFullyRevealed(gameState: GameState): boolean {
+    return this.dialoguePanel.isCurrentLineFullyRevealed(gameState);
+  }
+
+  public completeDialogueLine(gameState: GameState): boolean {
+    return this.dialoguePanel.completeCurrentLine(gameState);
+  }
+
   public render(ctx: CanvasRenderingContext2D, gameState: GameState): void {
     this.currentGameState = gameState;
     const { width, height } = ctx.canvas;
@@ -419,16 +430,25 @@ export class Hud {
 
     ctx.restore();
 
-    this.loadoutStrip.render(ctx, gameState);
+    const dialogueOcclusion = this.dialoguePanel.getOcclusionProgress();
+    if (dialogueOcclusion < 0.98) {
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, 1 - dialogueOcclusion * 1.2);
+      this.loadoutStrip.render(ctx, gameState);
+      ctx.restore();
+    }
 
     // Render transient HUD messages (loot, craft, etc.)
     this.gameMessagesPanel.render(ctx, gameState);
 
     // Level + XP (centered above hotbar)
-    ctx.save();
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    this.experiencePanel.render(ctx, gameState);
-    ctx.restore();
+    if (dialogueOcclusion < 0.98) {
+      ctx.save();
+      ctx.globalAlpha = Math.max(0, 1 - dialogueOcclusion * 1.25);
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      this.experiencePanel.render(ctx, gameState);
+      ctx.restore();
+    }
 
     // Render mute button
     ctx.save();
@@ -443,7 +463,7 @@ export class Hud {
     // Health + stamina orbs (left/right of bottom loadout strip)
     const currentPlayer = getPlayer(gameState);
     const isZombiePlayer = currentPlayer?.isZombiePlayer?.() ?? false;
-    if (!isZombiePlayer) {
+    if (!isZombiePlayer && dialogueOcclusion < 0.98) {
       this.survivorStatusHud.renderHealthAndStamina(ctx, gameState, minimapHudLayout);
     }
 
@@ -462,6 +482,8 @@ export class Hud {
       my?.getQuestProgressPayload() ?? null,
     );
     ctx.restore();
+
+    this.dialoguePanel.render(ctx, gameState);
 
     // Render fullscreen map on top of everything else if open
     this.fullscreenMap.render(ctx, gameState);

--- a/packages/game-server/src/entities/environment/dialogue-survivor-npc.js
+++ b/packages/game-server/src/entities/environment/dialogue-survivor-npc.js
@@ -1,6 +1,7 @@
 import { Entity } from "@/entities/entity";
 import Positionable from "@/extensions/positionable";
 import Interactive from "@/extensions/interactive";
+import Collidable from "@/extensions/collidable";
 import { Entities } from "@shared/constants";
 import PoolManager from "@shared/util/pool-manager";
 import { getConfig } from "@shared/config";
@@ -24,6 +25,9 @@ export class DialogueSurvivorNpc extends Entity {
         const size = poolManager.vector2.claim(16, 16);
         const topLeft = poolManager.vector2.claim(tileX * TILE_SIZE, tileY * TILE_SIZE);
         this.addExtension(new Positionable(this).setSize(size).setPosition(topLeft));
+        this.addExtension(new Collidable(this)
+            .setSize(poolManager.vector2.claim(8, 8))
+            .setOffset(poolManager.vector2.claim(4, 4)));
         this.addExtension(new Interactive(this).onInteract(() => { }).setDisplayName("talk"));
     }
 }

--- a/packages/game-server/src/entities/environment/dialogue-survivor-npc.ts
+++ b/packages/game-server/src/entities/environment/dialogue-survivor-npc.ts
@@ -2,6 +2,7 @@ import { Entity } from "@/entities/entity";
 import { IGameManagers } from "@/managers/types";
 import Positionable from "@/extensions/positionable";
 import Interactive from "@/extensions/interactive";
+import Collidable from "@/extensions/collidable";
 import { Entities } from "@shared/constants";
 import PoolManager from "@shared/util/pool-manager";
 import { getConfig } from "@shared/config";
@@ -42,6 +43,11 @@ export class DialogueSurvivorNpc extends Entity {
     const topLeft = poolManager.vector2.claim(tileX * TILE_SIZE, tileY * TILE_SIZE);
 
     this.addExtension(new Positionable(this).setSize(size).setPosition(topLeft));
+    this.addExtension(
+      new Collidable(this)
+        .setSize(poolManager.vector2.claim(8, 8))
+        .setOffset(poolManager.vector2.claim(4, 4)),
+    );
     this.addExtension(
       new Interactive(this).onInteract(() => {}).setDisplayName("talk"),
     );


### PR DESCRIPTION
## Summary
- replace the floating NPC speech bubble with a bottom-screen RPG-style dialogue panel
- let interact finish the current typed line before advancing dialogue
- make dialogue NPCs collidable and hide the world-space prompt while dialogue is open

## Scope
This PR is intentionally limited to the NPC dialogue UI and collision behavior. It does not include the editor reload work, coordinate HUD/editor changes, or authored world-map placement changes.

## Verification
- diff isolated from upstream main in a clean worktree
- attempted TypeScript verification in the clean worktree, but this repo expects generated game-shared dist artifacts that are not present there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new dialogue panel UI system for displaying NPC interactions with smooth animations and character-by-character text reveal.
  * Added visual improvements to dialogue presentation, including support for NPC portraits and dynamic footer text.

* **Bug Fixes**
  * Fixed interaction prompts appearing while dialogue is actively open.
  * Improved dialogue advancement behavior to complete unrevealed text before proceeding.

* **Chores**
  * Enhanced NPC collision detection for better interaction zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->