### PR TITLE
feat(game-client): add reusable quest tracker

### DIFF
--- a/packages/game-client/src/ui/active-quest-tracker-panel.ts
+++ b/packages/game-client/src/ui/active-quest-tracker-panel.ts
@@ -1,9 +1,15 @@
 import type { GameState } from "@/state";
+import type { PlayerClient } from "@/entities/player";
+import { ClientPositionable } from "@/extensions/positionable";
+import { calculateHudScale, scaleHudValue } from "@/util/hud-scale";
 import type { WorldMapQuestDefinition } from "@shared/map/quest-types";
 import type { PlayerQuestStatePayload } from "@shared/quests/player-quest-state";
-import { calculateHudScale, scaleHudValue } from "@/util/hud-scale";
 import type { MinimapScreenRect } from "./minimap-hud-group-layout";
-import { getQuestObjectiveLine } from "./quest-display";
+import {
+  getQuestTrackerDistanceTiles,
+  getQuestTrackerHeading,
+} from "./quest-tracker-target";
+import { resolvePrimaryQuestTrackerForPlayer } from "./quest-tracker-runtime";
 
 function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
   const words = text.split(/\s+/);
@@ -33,22 +39,16 @@ function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number)
 export class ActiveQuestTrackerPanel {
   public render(
     ctx: CanvasRenderingContext2D,
+    gameState: GameState,
+    player: PlayerClient | null,
     quests: readonly WorldMapQuestDefinition[],
     progress: PlayerQuestStatePayload | null,
     minimapRect: MinimapScreenRect,
-    gameState?: GameState | null,
   ): void {
-    const st = progress ?? { active: {}, completed: [] };
-    const activeIds = Object.keys(st.active);
-    if (activeIds.length === 0) {
+    const tracker = resolvePrimaryQuestTrackerForPlayer(gameState, player, quests, progress);
+    if (!tracker) {
       return;
     }
-
-    const activeQuestId = activeIds[0]!;
-    const def = quests.find((quest) => quest.id === activeQuestId);
-    const title = def?.title?.trim() || activeQuestId;
-    const objective = getQuestObjectiveLine(def, st, activeQuestId, gameState);
-    const extraQuestCount = Math.max(0, activeIds.length - 1);
 
     const { width: canvasW, height: canvasH } = ctx.canvas;
     const hudScale = calculateHudScale(canvasW, canvasH);
@@ -74,7 +74,31 @@ export class ActiveQuestTrackerPanel {
     ctx.textBaseline = "top";
 
     ctx.font = `${bodyFontPx}px Arial`;
-    const wrappedObjective = wrapText(ctx, objective, textWidth);
+    const wrappedObjective = wrapText(ctx, tracker.objective, textWidth);
+    const targetLabel = tracker.target
+      ? `${tracker.target.kind === "turn_in" ? "Turn in" : "Go to"}: ${tracker.target.label}`
+      : null;
+    const wrappedTargetLabel = targetLabel ? wrapText(ctx, targetLabel, textWidth) : [];
+    const detailLines: string[] = [];
+    if (tracker.target && player?.hasExt(ClientPositionable)) {
+      const playerPos = player.getExt(ClientPositionable).getCenterPosition();
+      const heading = getQuestTrackerHeading(
+        playerPos.x,
+        playerPos.y,
+        tracker.target.worldX,
+        tracker.target.worldY,
+      );
+      const distanceTiles = getQuestTrackerDistanceTiles(
+        playerPos.x,
+        playerPos.y,
+        tracker.target.worldX,
+        tracker.target.worldY,
+      );
+      const roundedDistance =
+        distanceTiles >= 10 ? Math.round(distanceTiles).toString() : distanceTiles.toFixed(1);
+      detailLines.push(`${heading.glyph} ${heading.cardinal} · ${roundedDistance} tiles`);
+      detailLines.push(`Tile ${tracker.target.tileRow}, ${tracker.target.tileCol}`);
+    }
     const panelHeight =
       panelPad * 2 +
       headerFontPx +
@@ -82,7 +106,13 @@ export class ActiveQuestTrackerPanel {
       titleFontPx +
       scaleHudValue(6, canvasW, canvasH) +
       wrappedObjective.length * lineHeight +
-      (extraQuestCount > 0 ? lineHeight : 0);
+      (wrappedTargetLabel.length > 0
+        ? scaleHudValue(6, canvasW, canvasH) + wrappedTargetLabel.length * lineHeight
+        : 0) +
+      (detailLines.length > 0
+        ? scaleHudValue(4, canvasW, canvasH) + detailLines.length * lineHeight
+        : 0) +
+      (tracker.extraQuestCount > 0 ? lineHeight : 0);
 
     const gradient = ctx.createLinearGradient(x, y, x, y + panelHeight);
     gradient.addColorStop(0, "rgba(17, 25, 40, 0.96)");
@@ -104,7 +134,7 @@ export class ActiveQuestTrackerPanel {
     textY += headerFontPx + scaleHudValue(8, canvasW, canvasH);
     ctx.font = `bold ${titleFontPx}px Arial`;
     ctx.fillStyle = "rgba(245, 249, 255, 0.98)";
-    ctx.fillText(title, x + panelPad, textY);
+    ctx.fillText(tracker.title, x + panelPad, textY);
 
     textY += titleFontPx + scaleHudValue(6, canvasW, canvasH);
     ctx.font = `${bodyFontPx}px Arial`;
@@ -114,9 +144,27 @@ export class ActiveQuestTrackerPanel {
       textY += lineHeight;
     }
 
-    if (extraQuestCount > 0) {
+    if (wrappedTargetLabel.length > 0) {
+      textY += scaleHudValue(6, canvasW, canvasH);
+      ctx.fillStyle = "rgba(255, 223, 155, 0.95)";
+      for (const line of wrappedTargetLabel) {
+        ctx.fillText(line, x + panelPad, textY);
+        textY += lineHeight;
+      }
+    }
+
+    if (detailLines.length > 0) {
+      textY += scaleHudValue(4, canvasW, canvasH);
+      ctx.fillStyle = "rgba(154, 222, 255, 0.92)";
+      for (const line of detailLines) {
+        ctx.fillText(line, x + panelPad, textY);
+        textY += lineHeight;
+      }
+    }
+
+    if (tracker.extraQuestCount > 0) {
       ctx.fillStyle = "rgba(140, 156, 180, 0.9)";
-      ctx.fillText(`+${extraQuestCount} more active`, x + panelPad, textY);
+      ctx.fillText(`+${tracker.extraQuestCount} more active`, x + panelPad, textY);
     }
 
     ctx.restore();

--- a/packages/game-client/src/ui/fullscreen-map.ts
+++ b/packages/game-client/src/ui/fullscreen-map.ts
@@ -24,6 +24,7 @@ import {
   RPG_PANEL_GRADIENT_BOTTOM,
   RPG_TITLE_CREAM,
 } from "./rpg-hud-theme";
+import { resolvePrimaryQuestTrackerForPlayer } from "./quest-tracker-runtime";
 
 const FULLSCREEN_MAP_SETTINGS = {
   padding: 180, // Padding from screen edges
@@ -263,10 +264,10 @@ export class FullScreenMap {
       mapHeight
     );
 
-    // Quest objective (waypoint / NPC) — after POIs so the marker stays visible
-    this.renderQuestNavigationMarker(
+    this.renderQuestTargetIndicator(
       ctx,
       gameState,
+      myPlayer,
       effectiveCenterPos,
       zoom,
       centerX,
@@ -347,6 +348,68 @@ export class FullScreenMap {
     ctx.lineWidth = 2;
     ctx.strokeRect(zoomOutX, zoomOutY, buttonSize, buttonSize);
     ctx.fillText("-", zoomOutX + buttonSize / 2, buttonY);
+  }
+
+  private renderQuestTargetIndicator(
+    ctx: CanvasRenderingContext2D,
+    gameState: GameState,
+    myPlayer: PlayerClient,
+    centerWorldPos: { x: number; y: number },
+    zoom: number,
+    centerX: number,
+    centerY: number,
+    mapWidth: number,
+    mapHeight: number
+  ): void {
+    const tracker = resolvePrimaryQuestTrackerForPlayer(
+      gameState,
+      myPlayer,
+      this.mapManager.getAuthoredQuests(),
+      myPlayer.getQuestProgressPayload()
+    );
+    if (!tracker?.target) {
+      return;
+    }
+
+    const offsetX = (tracker.target.worldX - centerWorldPos.x) * zoom;
+    const offsetY = (tracker.target.worldY - centerWorldPos.y) * zoom;
+    const inset = 18;
+    const clampedOffsetX = Math.max(
+      -(mapWidth / 2 - inset),
+      Math.min(mapWidth / 2 - inset, offsetX)
+    );
+    const clampedOffsetY = Math.max(
+      -(mapHeight / 2 - inset),
+      Math.min(mapHeight / 2 - inset, offsetY)
+    );
+    const drawX = centerX + clampedOffsetX;
+    const drawY = centerY + clampedOffsetY;
+    const isTurnIn = tracker.target.kind === "turn_in";
+    const pulse = 1 + Math.sin(Date.now() * 0.01) * 0.12;
+    const markerRadius = 12 * Math.max(0.85, zoom) * pulse;
+
+    ctx.save();
+    ctx.fillStyle = isTurnIn ? "rgba(99, 240, 174, 0.18)" : "rgba(255, 216, 107, 0.18)";
+    ctx.beginPath();
+    ctx.arc(drawX, drawY, markerRadius + 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = isTurnIn ? "rgba(99, 240, 174, 0.98)" : "rgba(255, 216, 107, 0.98)";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    ctx.moveTo(drawX, drawY - markerRadius);
+    ctx.lineTo(drawX + markerRadius, drawY);
+    ctx.lineTo(drawX, drawY + markerRadius);
+    ctx.lineTo(drawX - markerRadius, drawY);
+    ctx.closePath();
+    ctx.stroke();
+
+    ctx.fillStyle = "#ffffff";
+    ctx.font = `bold ${Math.max(12, Math.round(12 * Math.max(1, zoom)))}px Arial`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(isTurnIn ? "?" : "!", drawX, drawY + 0.5);
+    ctx.restore();
   }
 
   private prerenderCollidables(): void {
@@ -625,58 +688,6 @@ export class FullScreenMap {
       ctx.stroke();
       ctx.strokeRect(mapX - iconSize / 6, mapY - iconSize / 6, iconSize / 3, iconSize / 2);
     }
-  }
-
-  private renderQuestNavigationMarker(
-    ctx: CanvasRenderingContext2D,
-    gameState: GameState,
-    playerPos: { x: number; y: number },
-    zoom: number,
-    centerX: number,
-    centerY: number,
-    mapWidth: number,
-    mapHeight: number,
-  ): void {
-    const myPlayer = getPlayer(gameState);
-    if (!myPlayer || myPlayer.isZombiePlayer()) {
-      return;
-    }
-    const target = gameState.questNavigationTarget;
-    if (!target) {
-      return;
-    }
-
-    const maxDistance = Math.sqrt(((mapWidth / zoom) ** 2 + (mapHeight / zoom) ** 2) / 4);
-    const poolManager = PoolManager.getInstance();
-    const playerWorldPos = poolManager.vector2.claim(playerPos.x, playerPos.y);
-    const targetWorldPos = poolManager.vector2.claim(target.worldX, target.worldY);
-    const dist = distance(playerWorldPos, targetWorldPos);
-    poolManager.vector2.release(playerWorldPos);
-    poolManager.vector2.release(targetWorldPos);
-    if (dist > maxDistance) {
-      return;
-    }
-
-    const relativeX = target.worldX - playerPos.x;
-    const relativeY = target.worldY - playerPos.y;
-    const screenX = centerX + relativeX * zoom;
-    const screenY = centerY + relativeY * zoom;
-
-    const pulse = 0.72 + 0.28 * Math.sin(performance.now() / 300);
-    const s = 12 * Math.max(0.5, zoom);
-    ctx.save();
-    ctx.fillStyle = `rgba(255, 214, 120, ${pulse})`;
-    ctx.strokeStyle = "rgba(255, 255, 255, 0.95)";
-    ctx.lineWidth = 2 * Math.max(0.5, zoom);
-    ctx.beginPath();
-    ctx.moveTo(screenX, screenY - s);
-    ctx.lineTo(screenX + s, screenY);
-    ctx.lineTo(screenX, screenY + s);
-    ctx.lineTo(screenX - s, screenY);
-    ctx.closePath();
-    ctx.fill();
-    ctx.stroke();
-    ctx.restore();
   }
 
   private renderBiomeIndicators(

--- a/packages/game-client/src/ui/hud.ts
+++ b/packages/game-client/src/ui/hud.ts
@@ -501,10 +501,11 @@ export class Hud {
     if (!this.questJournalPanel.isVisible()) {
       this.activeQuestTrackerPanel.render(
         ctx,
+        gameState,
+        myPlayer,
         this.mapManager.getAuthoredQuests(),
         myPlayer?.getQuestProgressPayload() ?? null,
         minimapHudLayout.minimap,
-        gameState,
       );
     }
 

--- a/packages/game-client/src/ui/minimap.ts
+++ b/packages/game-client/src/ui/minimap.ts
@@ -22,6 +22,7 @@ import { renderMinimapFogOfWar } from "./utils/map-fog-of-war-renderer";
 import type { MinimapScreenRect } from "./minimap-hud-group-layout";
 import { calculateHudScale } from "@/util/hud-scale";
 import { RPG_BORDER_GOLD, RPG_MINIMAP_BACKGROUND, RPG_TITLE_CREAM } from "@/ui/rpg-hud-theme";
+import { resolvePrimaryQuestTrackerForPlayer } from "./quest-tracker-runtime";
 
 // Performance optimization constants - adjust these to balance quality vs performance
 // To view performance stats in console, run:
@@ -328,19 +329,6 @@ export class Minimap {
     this.renderSurvivorIndicators(ctx, survivorEntities, playerPos, settings, top, scaledLeft, scaledSize);
     perfTimer.end("minimap:survivors");
 
-    perfTimer.start("minimap:questNav");
-    this.renderQuestNavigationMarker(
-      ctx,
-      gameState,
-      playerPos,
-      settings,
-      top,
-      scaledLeft,
-      scaledSize,
-      myPlayer,
-    );
-    perfTimer.end("minimap:questNav");
-
     // Draw radar circle border using scaled values
     ctx.strokeStyle = RPG_BORDER_GOLD;
     ctx.lineWidth = Math.max(2, Math.round(2 * calculateHudScale(canvasWidth, canvasHeight)));
@@ -379,6 +367,10 @@ export class Minimap {
     this.renderBiomeIndicators(ctx, gameState, playerPos, settings, top, scaledLeft, scaledSize);
     perfTimer.end("minimap:biomes");
 
+    perfTimer.start("minimap:questNav");
+    this.renderQuestTargetIndicator(ctx, gameState, myPlayer, settings, top, scaledLeft, scaledSize);
+    perfTimer.end("minimap:questNav");
+
     ctx.restore();
 
     const tileRow = Math.floor(playerPos.y / this.tileSize);
@@ -401,6 +393,69 @@ export class Minimap {
     ctx.restore();
 
     perfTimer.end("minimap:total");
+  }
+
+  private renderQuestTargetIndicator(
+    ctx: CanvasRenderingContext2D,
+    gameState: GameState,
+    myPlayer: PlayerClient,
+    settings: typeof MINIMAP_SETTINGS,
+    top: number,
+    scaledLeft: number,
+    scaledSize: number
+  ): void {
+    const tracker = resolvePrimaryQuestTrackerForPlayer(
+      gameState,
+      myPlayer,
+      this.mapManager.getAuthoredQuests(),
+      myPlayer.getQuestProgressPayload()
+    );
+    if (!tracker?.target || !myPlayer.hasExt(ClientPositionable)) {
+      return;
+    }
+
+    const playerPos = myPlayer.getExt(ClientPositionable).getCenterPosition();
+    const centerX = scaledLeft + scaledSize / 2;
+    const centerY = top + scaledSize / 2;
+    const radius = scaledSize / 2;
+    const relativeX = tracker.target.worldX - playerPos.x;
+    const relativeY = tracker.target.worldY - playerPos.y;
+    const angle = Math.atan2(relativeY, relativeX);
+    const projectedX = centerX + relativeX * settings.scale;
+    const projectedY = centerY + relativeY * settings.scale;
+    const edgeInset = 16;
+    const maxDist = radius - edgeInset;
+    const distFromCenter = Math.hypot(projectedX - centerX, projectedY - centerY);
+    const drawX =
+      distFromCenter <= maxDist ? projectedX : centerX + Math.cos(angle) * maxDist;
+    const drawY =
+      distFromCenter <= maxDist ? projectedY : centerY + Math.sin(angle) * maxDist;
+    const isTurnIn = tracker.target.kind === "turn_in";
+    const pulse = 1 + Math.sin(Date.now() * 0.01) * 0.12;
+    const markerRadius = 8 * pulse;
+
+    ctx.save();
+    ctx.fillStyle = isTurnIn ? "rgba(99, 240, 174, 0.22)" : "rgba(255, 216, 107, 0.22)";
+    ctx.beginPath();
+    ctx.arc(drawX, drawY, markerRadius + 4, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = isTurnIn ? "rgba(99, 240, 174, 0.95)" : "rgba(255, 216, 107, 0.95)";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(drawX, drawY - markerRadius);
+    ctx.lineTo(drawX + markerRadius, drawY);
+    ctx.lineTo(drawX, drawY + markerRadius);
+    ctx.lineTo(drawX - markerRadius, drawY);
+    ctx.closePath();
+    ctx.stroke();
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.96)";
+    ctx.font = "bold 10px Arial";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(isTurnIn ? "?" : "!", drawX, drawY + 0.5);
+    ctx.restore();
   }
 
   private renderBiomeIndicators(
@@ -746,59 +801,6 @@ export class Minimap {
       ctx.stroke();
       ctx.strokeRect(minimapX - iconSize / 6, minimapY - iconSize / 6, iconSize / 3, iconSize / 2);
     }
-  }
-
-  private renderQuestNavigationMarker(
-    ctx: CanvasRenderingContext2D,
-    gameState: GameState,
-    playerPos: { x: number; y: number },
-    settings: typeof MINIMAP_SETTINGS,
-    top: number,
-    scaledLeft: number,
-    scaledSize: number,
-    myPlayer: PlayerClient,
-  ): void {
-    if (myPlayer.isZombiePlayer()) {
-      return;
-    }
-    const target = gameState.questNavigationTarget;
-    if (!target) {
-      return;
-    }
-
-    const centerX = scaledLeft + scaledSize / 2;
-    const centerY = top + scaledSize / 2;
-    const radius = scaledSize / 2;
-
-    const relativeX = target.worldX - playerPos.x;
-    const relativeY = target.worldY - playerPos.y;
-    const angle = Math.atan2(relativeY, relativeX);
-    const minimapX = centerX + relativeX * settings.scale;
-    const minimapY = centerY + relativeY * settings.scale;
-
-    const edgeInset = 18;
-    const maxDist = radius - edgeInset;
-    const distFromCenter = Math.hypot(minimapX - centerX, minimapY - centerY);
-    const drawX =
-      distFromCenter <= maxDist ? minimapX : centerX + Math.cos(angle) * maxDist;
-    const drawY =
-      distFromCenter <= maxDist ? minimapY : centerY + Math.sin(angle) * maxDist;
-
-    const pulse = 0.72 + 0.28 * Math.sin(performance.now() / 300);
-    ctx.save();
-    ctx.fillStyle = `rgba(255, 214, 120, ${pulse})`;
-    ctx.strokeStyle = "rgba(255, 255, 255, 0.95)";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    const s = 8;
-    ctx.moveTo(drawX, drawY - s);
-    ctx.lineTo(drawX + s, drawY);
-    ctx.lineTo(drawX, drawY + s);
-    ctx.lineTo(drawX - s, drawY);
-    ctx.closePath();
-    ctx.fill();
-    ctx.stroke();
-    ctx.restore();
   }
 
   // renderToxicZones and renderFogOfWar moved to shared utilities

--- a/packages/game-client/src/ui/quest-tracker-runtime.ts
+++ b/packages/game-client/src/ui/quest-tracker-runtime.ts
@@ -1,0 +1,48 @@
+import { getEntitiesByType, type GameState } from "../state";
+import type { PlayerClient } from "../entities/player";
+import { DialogueSurvivorNpcClient } from "../entities/environment/dialogue-survivor-npc";
+import { ClientPositionable } from "../extensions/positionable";
+import type { WorldMapQuestDefinition } from "../../../game-shared/src/map/quest-types";
+import {
+  resolvePrimaryQuestTracker,
+  type QuestTrackerNpcCandidate,
+} from "./quest-tracker-target";
+
+export function collectQuestTrackerNpcCandidates(gameState: GameState): QuestTrackerNpcCandidate[] {
+  const out: QuestTrackerNpcCandidate[] = [];
+  for (const entity of getEntitiesByType(gameState, "dialogue_survivor_npc")) {
+    if (!(entity instanceof DialogueSurvivorNpcClient)) continue;
+    if (!entity.hasExt(ClientPositionable)) continue;
+    const position = entity.getExt(ClientPositionable).getCenterPosition();
+    const session = entity.getActiveDialogueSession(gameState);
+    const completesQuestId = String(session.completeQuestId ?? "").trim() || undefined;
+    out.push({
+      displayName: entity.displayName.trim(),
+      npcKey: entity.npcKey.trim(),
+      worldX: position.x,
+      worldY: position.y,
+      ...(completesQuestId ? { completesQuestId } : {}),
+    });
+  }
+  return out;
+}
+
+export function resolvePrimaryQuestTrackerForPlayer(
+  gameState: GameState,
+  player: PlayerClient | null,
+  quests: readonly WorldMapQuestDefinition[],
+  progress: unknown,
+) {
+  if (!player || !player.hasExt(ClientPositionable)) {
+    return null;
+  }
+  const position = player.getExt(ClientPositionable).getCenterPosition();
+  const npcCandidates = collectQuestTrackerNpcCandidates(gameState);
+  return resolvePrimaryQuestTracker(
+    quests,
+    progress as any,
+    position.x,
+    position.y,
+    npcCandidates,
+  );
+}

--- a/packages/game-client/src/ui/quest-tracker-runtime.ts
+++ b/packages/game-client/src/ui/quest-tracker-runtime.ts
@@ -8,20 +8,31 @@ import {
   type QuestTrackerNpcCandidate,
 } from "./quest-tracker-target";
 
+function getQuestTrackerCompletionIds(
+  dialogueSessions: readonly { completeQuestId?: string | null }[],
+): string[] {
+  const ids = new Set<string>();
+  for (const session of dialogueSessions) {
+    const questId = String(session.completeQuestId ?? "").trim();
+    if (!questId) continue;
+    ids.add(questId);
+  }
+  return [...ids];
+}
+
 export function collectQuestTrackerNpcCandidates(gameState: GameState): QuestTrackerNpcCandidate[] {
   const out: QuestTrackerNpcCandidate[] = [];
   for (const entity of getEntitiesByType(gameState, "dialogue_survivor_npc")) {
     if (!(entity instanceof DialogueSurvivorNpcClient)) continue;
     if (!entity.hasExt(ClientPositionable)) continue;
     const position = entity.getExt(ClientPositionable).getCenterPosition();
-    const session = entity.getActiveDialogueSession(gameState);
-    const completesQuestId = String(session.completeQuestId ?? "").trim() || undefined;
+    const completesQuestIds = getQuestTrackerCompletionIds(entity.dialogueSessions);
     out.push({
       displayName: entity.displayName.trim(),
       npcKey: entity.npcKey.trim(),
       worldX: position.x,
       worldY: position.y,
-      ...(completesQuestId ? { completesQuestId } : {}),
+      ...(completesQuestIds.length > 0 ? { completesQuestIds } : {}),
     });
   }
   return out;

--- a/packages/game-client/src/ui/quest-tracker-target.test.ts
+++ b/packages/game-client/src/ui/quest-tracker-target.test.ts
@@ -88,6 +88,36 @@ describe("quest-tracker-target", () => {
     });
   });
 
+  it("resolves turn-in target when the quest is completed by a non-active dialogue branch", () => {
+    const quests = [
+      {
+        id: "intro",
+        title: "Scout",
+        steps: [{ type: "pickup_item", itemType: "bandage" }],
+        rewards: [],
+        startRewards: [],
+      },
+    ];
+    const progress = activeProgress(1);
+    const candidates: QuestTrackerNpcCandidate[] = [
+      {
+        displayName: "Quartermaster",
+        npcKey: "7,8",
+        worldX: 160,
+        worldY: 144,
+        completesQuestIds: ["other_quest", "intro"],
+      },
+    ];
+
+    const resolution = resolvePrimaryQuestTracker(quests, progress, 0, 0, candidates);
+    expect(resolution?.target).toMatchObject({
+      kind: "turn_in",
+      label: "Quartermaster",
+      tileRow: 7,
+      tileCol: 8,
+    });
+  });
+
   it("computes heading and tile distance", () => {
     expect(getQuestTrackerHeading(0, 0, 64, -64)).toMatchObject({
       cardinal: "NE",

--- a/packages/game-client/src/ui/quest-tracker-target.test.ts
+++ b/packages/game-client/src/ui/quest-tracker-target.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  getQuestTrackerDistanceTiles,
+  getQuestTrackerHeading,
+  resolvePrimaryQuestTracker,
+  type QuestTrackerNpcCandidate,
+} from "./quest-tracker-target";
+
+const activeProgress = (step: number) => ({
+  active: { intro: { step } },
+  completed: [],
+});
+
+describe("quest-tracker-target", () => {
+  it("resolves waypoint targets from quest steps", () => {
+    const quests = [
+      {
+        id: "intro",
+        title: "Scout",
+        steps: [{ type: "reach_waypoint", row: 10, col: 5 }],
+        rewards: [],
+        startRewards: [],
+      },
+    ];
+
+    const resolution = resolvePrimaryQuestTracker(quests, activeProgress(0), 0, 0, []);
+    expect(resolution?.target).toMatchObject({
+      kind: "waypoint",
+      label: "Waypoint",
+      tileRow: 10,
+      tileCol: 5,
+    });
+  });
+
+  it("resolves talk-to-npc targets using nearest matching candidate", () => {
+    const quests = [
+      {
+        id: "intro",
+        title: "Scout",
+        steps: [{ type: "talk_to_npc", npcName: "Mara", npcKey: "3,4" }],
+        rewards: [],
+        startRewards: [],
+      },
+    ];
+    const candidates: QuestTrackerNpcCandidate[] = [
+      { displayName: "Mara", npcKey: "3,4", worldX: 96, worldY: 96 },
+      { displayName: "Mara", npcKey: "3,4", worldX: 900, worldY: 900 },
+    ];
+
+    const resolution = resolvePrimaryQuestTracker(quests, activeProgress(0), 100, 100, candidates);
+    expect(resolution?.target).toMatchObject({
+      kind: "talk_to_npc",
+      label: "Mara",
+      tileRow: 3,
+      tileCol: 4,
+      worldX: 96,
+      worldY: 96,
+    });
+  });
+
+  it("resolves turn-in target after objective steps are done", () => {
+    const quests = [
+      {
+        id: "intro",
+        title: "Scout",
+        steps: [{ type: "pickup_item", itemType: "bandage" }],
+        rewards: [],
+        startRewards: [],
+      },
+    ];
+    const progress = activeProgress(1);
+    const candidates: QuestTrackerNpcCandidate[] = [
+      {
+        displayName: "Quartermaster",
+        npcKey: "7,8",
+        worldX: 160,
+        worldY: 144,
+        completesQuestId: "intro",
+      },
+    ];
+
+    const resolution = resolvePrimaryQuestTracker(quests, progress, 0, 0, candidates);
+    expect(resolution?.target).toMatchObject({
+      kind: "turn_in",
+      label: "Quartermaster",
+      tileRow: 7,
+      tileCol: 8,
+    });
+  });
+
+  it("computes heading and tile distance", () => {
+    expect(getQuestTrackerHeading(0, 0, 64, -64)).toMatchObject({
+      cardinal: "NE",
+      glyph: "↗",
+    });
+    expect(getQuestTrackerDistanceTiles(0, 0, 64, 0)).toBe(4);
+  });
+});

--- a/packages/game-client/src/ui/quest-tracker-target.ts
+++ b/packages/game-client/src/ui/quest-tracker-target.ts
@@ -12,6 +12,7 @@ export interface QuestTrackerNpcCandidate {
   worldX: number;
   worldY: number;
   completesQuestId?: string;
+  completesQuestIds?: readonly string[];
 }
 
 export interface QuestTrackerTarget {
@@ -180,7 +181,12 @@ function resolveTurnInTarget(
   playerWorldX: number,
   playerWorldY: number,
 ): QuestTrackerTarget | null {
-  const turnInCandidates = candidates.filter((candidate) => candidate.completesQuestId === questId);
+  const turnInCandidates = candidates.filter((candidate) => {
+    if (candidate.completesQuestId === questId) {
+      return true;
+    }
+    return candidate.completesQuestIds?.includes(questId) === true;
+  });
   const nearest = chooseClosestNpcCandidate(turnInCandidates, playerWorldX, playerWorldY);
   if (!nearest) return null;
   return createTarget(

--- a/packages/game-client/src/ui/quest-tracker-target.ts
+++ b/packages/game-client/src/ui/quest-tracker-target.ts
@@ -1,0 +1,313 @@
+import { getConfig } from "../../../game-shared/src/config";
+import {
+  talkToNpcStepMatchesNpc,
+  type WorldMapQuestDefinition,
+} from "../../../game-shared/src/map/quest-types";
+
+export type QuestTrackerTargetKind = "waypoint" | "talk_to_npc" | "turn_in";
+
+export interface QuestTrackerNpcCandidate {
+  displayName: string;
+  npcKey: string;
+  worldX: number;
+  worldY: number;
+  completesQuestId?: string;
+}
+
+export interface QuestTrackerTarget {
+  kind: QuestTrackerTargetKind;
+  label: string;
+  worldX: number;
+  worldY: number;
+  tileRow: number;
+  tileCol: number;
+}
+
+export interface QuestTrackerResolution {
+  questId: string;
+  title: string;
+  objective: string;
+  stepIndex: number;
+  stepTotal: number;
+  extraQuestCount: number;
+  target: QuestTrackerTarget | null;
+}
+
+type QuestTrackerStep = WorldMapQuestDefinition["steps"][number];
+
+type QuestTrackerActiveEntryLike = {
+  step?: unknown;
+  kills?: Record<string, number>;
+} | number;
+
+type QuestTrackerProgressLike = {
+  active: Record<string, QuestTrackerActiveEntryLike>;
+  completed: string[];
+};
+
+export interface QuestTrackerHeading {
+  angle: number;
+  cardinal: string;
+  glyph: string;
+}
+
+const QUEST_TRACKER_HEADINGS: ReadonlyArray<QuestTrackerHeading> = [
+  { angle: 0, cardinal: "E", glyph: "→" },
+  { angle: Math.PI / 4, cardinal: "SE", glyph: "↘" },
+  { angle: Math.PI / 2, cardinal: "S", glyph: "↓" },
+  { angle: (3 * Math.PI) / 4, cardinal: "SW", glyph: "↙" },
+  { angle: Math.PI, cardinal: "W", glyph: "←" },
+  { angle: (5 * Math.PI) / 4, cardinal: "NW", glyph: "↖" },
+  { angle: (3 * Math.PI) / 2, cardinal: "N", glyph: "↑" },
+  { angle: (7 * Math.PI) / 4, cardinal: "NE", glyph: "↗" },
+];
+
+function parseNpcKeyToTile(npcKey: string): { row: number; col: number } | null {
+  const trimmed = npcKey.trim();
+  if (!trimmed) return null;
+  const [rowRaw, colRaw] = trimmed.split(",");
+  const row = Number.parseInt(rowRaw ?? "", 10);
+  const col = Number.parseInt(colRaw ?? "", 10);
+  if (!Number.isInteger(row) || !Number.isInteger(col)) {
+    return null;
+  }
+  return { row, col };
+}
+
+function getActiveStepIndex(st: QuestTrackerProgressLike, qid: string): number {
+  const raw = st.active[qid];
+  if (typeof raw === "number" && Number.isInteger(raw) && raw >= 0) {
+    return raw;
+  }
+  if (raw && typeof raw === "object" && typeof raw.step === "number" && Number.isInteger(raw.step)) {
+    return Math.max(0, raw.step);
+  }
+  return 0;
+}
+
+function worldToTile(worldX: number, worldY: number): { row: number; col: number } {
+  const tileSize = getConfig().world.TILE_SIZE;
+  return {
+    row: Math.floor(worldY / tileSize),
+    col: Math.floor(worldX / tileSize),
+  };
+}
+
+function tileToWorld(row: number, col: number): { worldX: number; worldY: number } {
+  const tileSize = getConfig().world.TILE_SIZE;
+  return {
+    worldX: col * tileSize + tileSize / 2,
+    worldY: row * tileSize + tileSize / 2,
+  };
+}
+
+function createTarget(
+  kind: QuestTrackerTargetKind,
+  label: string,
+  worldX: number,
+  worldY: number,
+  tileHint?: { row: number; col: number } | null,
+): QuestTrackerTarget {
+  const tile = tileHint ?? worldToTile(worldX, worldY);
+  return {
+    kind,
+    label,
+    worldX,
+    worldY,
+    tileRow: tile.row,
+    tileCol: tile.col,
+  };
+}
+
+function chooseClosestNpcCandidate(
+  candidates: readonly QuestTrackerNpcCandidate[],
+  playerWorldX: number,
+  playerWorldY: number,
+): QuestTrackerNpcCandidate | null {
+  if (candidates.length === 0) return null;
+  let best: QuestTrackerNpcCandidate | null = null;
+  let bestDistSq = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const dx = candidate.worldX - playerWorldX;
+    const dy = candidate.worldY - playerWorldY;
+    const distSq = dx * dx + dy * dy;
+    if (distSq < bestDistSq) {
+      best = candidate;
+      bestDistSq = distSq;
+    }
+  }
+  return best;
+}
+
+function resolveTalkToNpcTarget(
+  step: { npcName?: string; npcKey?: string },
+  candidates: readonly QuestTrackerNpcCandidate[],
+  playerWorldX: number,
+  playerWorldY: number,
+): QuestTrackerTarget | null {
+  const matches = candidates.filter((candidate) =>
+    talkToNpcStepMatchesNpc(step, candidate.displayName, candidate.npcKey),
+  );
+  const nearest = chooseClosestNpcCandidate(matches, playerWorldX, playerWorldY);
+  if (nearest) {
+    return createTarget(
+      "talk_to_npc",
+      nearest.displayName.trim() || "Survivor",
+      nearest.worldX,
+      nearest.worldY,
+      parseNpcKeyToTile(nearest.npcKey),
+    );
+  }
+
+  const fallbackTile = step.npcKey ? parseNpcKeyToTile(step.npcKey) : null;
+  if (fallbackTile) {
+    const world = tileToWorld(fallbackTile.row, fallbackTile.col);
+    return createTarget(
+      "talk_to_npc",
+      step.npcName?.trim() || "Survivor",
+      world.worldX,
+      world.worldY,
+      fallbackTile,
+    );
+  }
+
+  return null;
+}
+
+function resolveTurnInTarget(
+  questId: string,
+  candidates: readonly QuestTrackerNpcCandidate[],
+  playerWorldX: number,
+  playerWorldY: number,
+): QuestTrackerTarget | null {
+  const turnInCandidates = candidates.filter((candidate) => candidate.completesQuestId === questId);
+  const nearest = chooseClosestNpcCandidate(turnInCandidates, playerWorldX, playerWorldY);
+  if (!nearest) return null;
+  return createTarget(
+    "turn_in",
+    nearest.displayName.trim() || "Survivor",
+    nearest.worldX,
+    nearest.worldY,
+    parseNpcKeyToTile(nearest.npcKey),
+  );
+}
+
+function describeQuestTrackerStep(
+  step: QuestTrackerStep | undefined,
+  activeEntry?: QuestTrackerActiveEntryLike,
+): string {
+  if (!step) return "(unknown step)";
+  if (step.type === "pickup_item") return `Pick up ${step.itemType}`;
+  if (step.type === "reach_waypoint") return `Go to tile ${step.row}, ${step.col}`;
+  if (step.type === "kill_enemies") {
+    const kills =
+      activeEntry && typeof activeEntry === "object" && !Array.isArray(activeEntry)
+        ? activeEntry.kills?.[step.enemyType] ?? 0
+        : 0;
+    return `Kill ${kills}/${step.count} ${step.enemyType}`;
+  }
+  if (step.type === "talk_to_npc") {
+    if (step.npcName?.trim()) return `Talk to ${step.npcName.trim()}`;
+    if (step.npcKey?.trim()) return `Talk to survivor at ${step.npcKey.trim()}`;
+    return "Talk to an NPC";
+  }
+  return "(unknown step)";
+}
+
+function getQuestTrackerObjectiveLine(
+  def: WorldMapQuestDefinition | undefined,
+  progress: QuestTrackerProgressLike,
+  questId: string,
+): string {
+  const stepIdx = getActiveStepIndex(progress, questId);
+  const stepTotal = def?.steps.length ?? 0;
+  if (!def || stepTotal === 0) {
+    return "Objectives ready";
+  }
+  if (stepIdx >= stepTotal) {
+    return "Objectives done";
+  }
+  const stepSummary = describeQuestTrackerStep(def.steps[stepIdx], progress.active[questId]);
+  return `Step ${stepIdx + 1}/${stepTotal} · ${stepSummary}`;
+}
+
+export function resolvePrimaryQuestTracker(
+  quests: readonly WorldMapQuestDefinition[],
+  progress: QuestTrackerProgressLike | null,
+  playerWorldX: number,
+  playerWorldY: number,
+  npcCandidates: readonly QuestTrackerNpcCandidate[],
+): QuestTrackerResolution | null {
+  const state = progress ?? { active: {}, completed: [] };
+  const activeIds = Object.keys(state.active);
+  if (activeIds.length === 0) {
+    return null;
+  }
+
+  const questId = activeIds[0]!;
+  const def = quests.find((quest) => quest.id === questId);
+  const stepIndex = getActiveStepIndex(state, questId);
+  const stepTotal = def?.steps.length ?? 0;
+
+  let target: QuestTrackerTarget | null = null;
+  if (def) {
+    if (stepIndex >= stepTotal || stepTotal === 0) {
+      target = resolveTurnInTarget(questId, npcCandidates, playerWorldX, playerWorldY);
+    } else {
+      const step = def.steps[stepIndex];
+      switch (step?.type) {
+        case "reach_waypoint": {
+          const world = tileToWorld(step.row, step.col);
+          target = createTarget("waypoint", "Waypoint", world.worldX, world.worldY, {
+            row: step.row,
+            col: step.col,
+          });
+          break;
+        }
+        case "talk_to_npc":
+          target = resolveTalkToNpcTarget(step, npcCandidates, playerWorldX, playerWorldY);
+          break;
+        default:
+          target = null;
+      }
+    }
+  }
+
+  return {
+    questId,
+    title: def?.title?.trim() || questId,
+    objective: getQuestTrackerObjectiveLine(def, state, questId),
+    stepIndex,
+    stepTotal,
+    extraQuestCount: Math.max(0, activeIds.length - 1),
+    target,
+  };
+}
+
+export function getQuestTrackerHeading(
+  playerWorldX: number,
+  playerWorldY: number,
+  targetWorldX: number,
+  targetWorldY: number,
+): QuestTrackerHeading {
+  const dx = targetWorldX - playerWorldX;
+  const dy = targetWorldY - playerWorldY;
+  if (Math.abs(dx) < 1 && Math.abs(dy) < 1) {
+    return { angle: 0, cardinal: "HERE", glyph: "•" };
+  }
+  const rawAngle = Math.atan2(dy, dx);
+  const normalized = rawAngle < 0 ? rawAngle + Math.PI * 2 : rawAngle;
+  const index = Math.round(normalized / (Math.PI / 4)) % QUEST_TRACKER_HEADINGS.length;
+  return QUEST_TRACKER_HEADINGS[index]!;
+}
+
+export function getQuestTrackerDistanceTiles(
+  playerWorldX: number,
+  playerWorldY: number,
+  targetWorldX: number,
+  targetWorldY: number,
+): number {
+  const dx = targetWorldX - playerWorldX;
+  const dy = targetWorldY - playerWorldY;
+  return Math.sqrt(dx * dx + dy * dy) / getConfig().world.TILE_SIZE;
+}


### PR DESCRIPTION
## Summary
- add a reusable quest tracker target resolver for active quest steps
- enrich the active quest HUD panel with target label, heading, distance, and tile coordinates
- render the tracked quest target on the minimap and fullscreen map

## Verification
- ../../node_modules/.bin/vitest run src/ui/quest-tracker-target.test.ts

## Notes
- this branch was cut from the current upstream main and cherry-picked cleanly so the PR contains only the quest-tracker work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quest tracker panel now shows a "Turn in/Go to" line with cardinal heading, rounded distance in tiles, and tile coordinates; panel height adjusts to fit these details.
  * Minimap and fullscreen map quest indicators updated with pulsing markers and distinct styling/labels for turn-in vs destination objectives.

* **Tests**
  * Added tests covering quest target resolution, heading, and distance calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->